### PR TITLE
✨[Feat] 게시물 관련 도메인 엔티티·Repo 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+src/main/generated/
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/java/DNBN/spring/converter/MemberConverter.java
+++ b/src/main/java/DNBN/spring/converter/MemberConverter.java
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 public class MemberConverter {
     public static MemberResponseDTO.OnboardingResultDTO toOnboardingResponseDTO(Member member) {
         return MemberResponseDTO.OnboardingResultDTO.builder()
-                .memberId(member.getId())
+                .memberId(member.getMemberId())
                 .nickname(member.getNickname())
                 .chosenRegionIds(
                         member.getLikePlaceList().stream()
@@ -35,7 +35,7 @@ public class MemberConverter {
                 .collect(Collectors.toList());
 
         return MemberResponseDTO.MemberInfoDTO.builder()
-                .memberId(member.getId())
+                .memberId(member.getMemberId())
                 .nickname(member.getNickname())
                 .profileImage(member.getProfileImage())
                 .likePlaces(likePlaces)

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -1,0 +1,54 @@
+package DNBN.spring.domain;
+
+import DNBN.spring.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Article extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long articleId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "category_id", nullable = false)
+  private Category category;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "place_id", nullable = false)
+  private Place place;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id", nullable = false)
+  private Region region;
+
+  @Column(nullable = false, length = 255)
+  private String title;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @Builder.Default
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long likesCount = 0L;
+
+  @Builder.Default
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long spamCount = 0L;
+
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/DNBN/spring/domain/ArticlePhoto.java
+++ b/src/main/java/DNBN/spring/domain/ArticlePhoto.java
@@ -29,10 +29,6 @@ public class ArticlePhoto extends BaseEntity {
   private Place place;
 
   @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id", nullable = false)
-  private Member member;
-
-  @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "region_id", nullable = false)
   private Region region;
 

--- a/src/main/java/DNBN/spring/domain/ArticlePhoto.java
+++ b/src/main/java/DNBN/spring/domain/ArticlePhoto.java
@@ -1,0 +1,50 @@
+package DNBN.spring.domain;
+
+import DNBN.spring.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ArticlePhoto extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long articlePhotoId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "article_id", nullable = false)
+  private Article article;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "place_id", nullable = false)
+  private Place place;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id", nullable = false)
+  private Region region;
+
+  @Column(nullable = false, length = 500)
+  private String fileKey;
+
+  @Column(nullable = false)
+  private Integer orderIndex;
+
+  @Builder.Default
+  @Column(nullable = false)
+  private Boolean isMain = false;
+
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/DNBN/spring/domain/Category.java
+++ b/src/main/java/DNBN/spring/domain/Category.java
@@ -1,0 +1,47 @@
+package DNBN.spring.domain;
+
+import DNBN.spring.domain.common.BaseEntity;
+import DNBN.spring.domain.enums.Color;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(
+    uniqueConstraints = @UniqueConstraint(columnNames = {"member_id", "name"})
+)
+public class Category extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long categoryId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "place_id", nullable = false)
+  private Place place;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id", nullable = false)
+  private Region region;
+
+  @Column(nullable = false, length = 100)
+  private String name;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false, length = 10)
+  private Color color;
+
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/DNBN/spring/domain/Comment.java
+++ b/src/main/java/DNBN/spring/domain/Comment.java
@@ -1,0 +1,65 @@
+package DNBN.spring.domain;
+
+import DNBN.spring.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Comment extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long commentId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "article_id", nullable = false)
+  private Article article;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "member_id", nullable = false)
+  private Member member;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "place_id", nullable = false)
+  private Place place;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id", nullable = false)
+  private Region region;
+
+  @Builder.Default
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long likeCount = 0L;
+
+  @Builder.Default
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long suspectCount = 0L;
+
+  @Builder.Default
+  @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long commentCount = 0L;
+
+  @Column(nullable = false, columnDefinition = "TEXT")
+  private String content;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "parent_comment_id")
+  private Comment parentComment;
+
+  @OneToMany(mappedBy = "parentComment", cascade = CascadeType.ALL)
+  @Builder.Default
+  private List<Comment> childComments = new ArrayList<>();
+
+  private LocalDateTime deletedAt;
+}

--- a/src/main/java/DNBN/spring/domain/Member.java
+++ b/src/main/java/DNBN/spring/domain/Member.java
@@ -21,7 +21,7 @@ import java.util.List;
 public class Member extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private Long memberId;
 
     @Column(nullable = false, unique = true)
     private String socialId;

--- a/src/main/java/DNBN/spring/domain/Place.java
+++ b/src/main/java/DNBN/spring/domain/Place.java
@@ -1,0 +1,28 @@
+package DNBN.spring.domain;
+
+import DNBN.spring.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.DynamicUpdate;
+
+@Entity
+@Getter
+@DynamicInsert
+@DynamicUpdate
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class Place extends BaseEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long placeId;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "region_id", nullable = false)
+  private Region region;
+
+  @Column(nullable = false, length = 50)
+  private String title;
+}

--- a/src/main/java/DNBN/spring/domain/enums/Color.java
+++ b/src/main/java/DNBN/spring/domain/enums/Color.java
@@ -1,0 +1,25 @@
+package DNBN.spring.domain.enums;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+public enum Color {
+  ORANGE, YELLOW, GREEN, BLUE, PURPLE, CORAL, PINK;
+
+  private static final Map<String, Color> BY_NAME =
+      Arrays.stream(values())
+          .collect(Collectors.toMap(
+              color -> color.name().toLowerCase(),
+              Function.identity()
+          ));
+
+  public static Color from(String value) {
+    Color color = BY_NAME.get(value.toLowerCase());
+    if (color == null) {
+      throw new IllegalArgumentException("지원하지 않는 색상입니다: " + value);
+    }
+    return color;
+  }
+}

--- a/src/main/java/DNBN/spring/repository/ArticlePhotoRepository/ArticlePhotoRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticlePhotoRepository/ArticlePhotoRepository.java
@@ -1,0 +1,17 @@
+package DNBN.spring.repository.ArticlePhotoRepository;
+
+import DNBN.spring.domain.ArticlePhoto;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ArticlePhotoRepository extends JpaRepository<ArticlePhoto, Long> {
+    List<ArticlePhoto> findAllByArticle(Article article);
+    List<ArticlePhoto> findAllByMember(Member member);
+    List<ArticlePhoto> findAllByPlace(Place place);
+    List<ArticlePhoto> findAllByRegion(Region region);
+}
+

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -1,0 +1,17 @@
+package DNBN.spring.repository.ArticleRepository;
+
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Category;
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface ArticleRepository extends JpaRepository<Article, Long> {
+    List<Article> findAllByMember(Member member);
+    List<Article> findAllByCategory(Category category);
+    List<Article> findAllByPlace(Place place);
+    List<Article> findAllByRegion(Region region);
+}
+

--- a/src/main/java/DNBN/spring/repository/CategoryRepository/CategoryRepository.java
+++ b/src/main/java/DNBN/spring/repository/CategoryRepository/CategoryRepository.java
@@ -1,0 +1,15 @@
+package DNBN.spring.repository.CategoryRepository;
+
+import DNBN.spring.domain.Category;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    List<Category> findAllByMember(Member member);
+    List<Category> findAllByPlace(Place place);
+    List<Category> findAllByRegion(Region region);
+}
+

--- a/src/main/java/DNBN/spring/repository/CommentRepository/CommentRepository.java
+++ b/src/main/java/DNBN/spring/repository/CommentRepository/CommentRepository.java
@@ -1,0 +1,17 @@
+package DNBN.spring.repository.CommentRepository;
+
+import DNBN.spring.domain.Comment;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findAllByArticle(Article article);
+    List<Comment> findAllByMember(Member member);
+    List<Comment> findAllByPlace(Place place);
+    List<Comment> findAllByRegion(Region region);
+}
+

--- a/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
@@ -1,0 +1,11 @@
+package DNBN.spring.repository.PlaceRepository;
+
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface PlaceRepository extends JpaRepository<Place, Long> {
+    List<Place> findAllByRegion(Region region);
+}
+

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -80,7 +80,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
         // JWT를 로컬(localStorage, 쿠키 등)에서 직접 제거해야 로그아웃
 
-        log.info("사용자 {} 로그아웃 처리 완료", member.getId());
+        log.info("사용자 {} 로그아웃 처리 완료", member.getMemberId());
     }
 
     @Override

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -45,7 +45,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
                 .accessToken(accessToken)
                 .refreshToken(refreshToken)
-                .memberId(member.getId())
+                .memberId(member.getMemberId())
                 .isOnboardingCompleted(member.isOnboardingCompleted())
                 .build();
 

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -29,7 +29,7 @@ public class AuthRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
     public ApiResponse<Void> logout(@AuthenticationPrincipal MemberDetails memberDetails) {
-        memberCommandService.logout(memberDetails.getMember().getId());
+        memberCommandService.logout(memberDetails.getMember().getMemberId());
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -29,7 +29,7 @@ public class MemberRestController {
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
     public ApiResponse<MemberResponseDTO.OnboardingResultDTO> onboard(@AuthenticationPrincipal MemberDetails memberDetails, @RequestBody @Valid MemberRequestDTO.OnboardingDTO request) {
-        Long memberId = memberDetails.getMember().getId();
+        Long memberId = memberDetails.getMember().getMemberId();
         return ApiResponse.onSuccess(memberCommandService.onboardingMember(memberId, request));
     }
 
@@ -48,7 +48,7 @@ public class MemberRestController {
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
     public ApiResponse<Void> deleteMember(@AuthenticationPrincipal MemberDetails memberDetails) {
-        memberCommandService.deleteMember(memberDetails.getMember().getId());
+        memberCommandService.deleteMember(memberDetails.getMember().getMemberId());
         return ApiResponse.onSuccess(null);
     }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> **Article, ArticlePhoto, Comment, Category, Place** 엔티티 및 레포지토리 구현

## 🛠️ 작업 상세 내용
- [x] `Article` 및 `ArticlePhoto`의 엔티티 및 레포지토리 구현
- [x] `Category`의 엔티티 및 레포지토리 구현
- [x] `Comment` 의 엔티티 및 레포지토리 구현
- [x] `Place` 의 엔티티 및 레포지토리 구현

## 📄 참고 코드 – Color enum
> `Color` enum은 문자열 값 매핑을 위해 **Map 기반 매핑 로직**을 추가하였습니다.

```java
package DNBN.spring.domain.enums;

import java.util.Arrays;
import java.util.Map;
import java.util.function.Function;
import java.util.stream.Collectors;

public enum Color {
  ORANGE, YELLOW, GREEN, BLUE, PURPLE, CORAL, PINK;

  private static final Map<String, Color> BY_NAME =
      Arrays.stream(values())
          .collect(Collectors.toMap(
              color -> color.name().toLowerCase(),
              Function.identity()
          ));

  public static Color from(String value) {
    Color color = BY_NAME.get(value.toLowerCase());
    if (color == null) {
      throw new IllegalArgumentException("지원하지 않는 색상입니다: " + value);
    }
    return color;
  }
}
```

## 💬 기타(공유사항 to 리뷰어)
- `.gitignore`에 `generated` 경로를 추가하여 QClass 파일 문제를 해결했습니다.
- 문자열 기반 enum 매핑을 위해, `Color` 클래스에 Map 기반 정적 매핑 로직을 추가했습니다.
  → stream 기반 초기화로 확장성과 성능을 고려했습니다.
- `deletedAt` 필드를 공통적으로 엔티티 안에 추가하였습니다. 추후`BaseEntity`로 관리 시 일괄 변경 예정