### PR TITLE
✨ [Feat] 구글 소셜 로그인 구현

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,37 @@
+package DNBN.spring.apiPayload.exception.handler;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.ErrorReasonDTO;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+//        ErrorReasonDTO reason = ErrorReasonDTO.of(ErrorStatus.INVALID_JWT_ACCESS_TOKEN);
+        ErrorReasonDTO reason = ErrorReasonDTO.builder()
+                .httpStatus(ErrorStatus.INVALID_JWT_ACCESS_TOKEN.getHttpStatus())
+                .isSuccess(false)
+                .code(ErrorStatus.INVALID_JWT_ACCESS_TOKEN.getCode())
+                .message(ErrorStatus.INVALID_JWT_ACCESS_TOKEN.getMessage())
+                .build();
+
+        response.getWriter().write(new ObjectMapper().writeValueAsString(
+                ApiResponse.onFailure(reason.getCode(), reason.getMessage(), reason)
+        ));
+    }
+}

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
@@ -22,7 +22,6 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 
-//        ErrorReasonDTO reason = ErrorReasonDTO.of(ErrorStatus.INVALID_JWT_ACCESS_TOKEN);
         ErrorReasonDTO reason = ErrorReasonDTO.builder()
                 .httpStatus(ErrorStatus.INVALID_JWT_ACCESS_TOKEN.getHttpStatus())
                 .isSuccess(false)

--- a/src/main/java/DNBN/spring/config/security/CustomUserDetailsService.java
+++ b/src/main/java/DNBN/spring/config/security/CustomUserDetailsService.java
@@ -1,5 +1,7 @@
 package DNBN.spring.config.security;
 
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.domain.Member;
 import DNBN.spring.domain.MemberDetails;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
@@ -17,7 +19,7 @@ public class CustomUserDetailsService implements UserDetailsService {
     @Override
     public UserDetails loadUserByUsername(String socialId) throws UsernameNotFoundException {
         Member member = memberRepository.findBySocialId(socialId)
-                .orElseThrow(() -> new UsernameNotFoundException("해당 소셜 ID의 유저가 존재하지 않습니다: " + socialId));
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.SOCIALID_NOT_FOUND));
 
 //        return org.springframework.security.core.userdetails.User
 //                .withUsername(member.getSocialId())

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -3,6 +3,7 @@ package DNBN.spring.config.security;
 import DNBN.spring.config.security.jwt.JwtAuthenticationFilter;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.service.OAuth2.CustomOAuth2UserService;
+import DNBN.spring.service.OAuth2.CustomOidcUserService;
 import DNBN.spring.service.OAuth2.OAuth2FailureHandler;
 import DNBN.spring.service.OAuth2.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
@@ -31,6 +32,7 @@ public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomOAuth2UserService customOAuth2UserService;
+    private final CustomOidcUserService customOidcUserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
 
@@ -102,9 +104,10 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
+                                .oidcUserService(customOidcUserService)
                                 .userService(customOAuth2UserService)
                         )
-                        .successHandler(oAuth2SuccessHandler)  // 온보딩 분기 등 커스텀 성공 핸들러
+                        .successHandler(oAuth2SuccessHandler) // 온보딩 분기 등 커스텀 성공 핸들러
                         .failureHandler(oAuth2FailureHandler)
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -49,8 +49,6 @@ public class SecurityConfig {
                 "http://localhost:3000", // 로컬 프론트
                 "http://localhost:8080" // 로컬 백엔드
         ));
-//        config.addAllowedOriginPattern("*");
-//        config.setAllowedOrigins(List.of("*"));
         config.setAllowedHeaders(List.of("*"));
         config.setExposedHeaders(List.of("Authorization"));  // JWT 토큰 읽기 허용
         config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"));
@@ -62,30 +60,6 @@ public class SecurityConfig {
         return source;
     }
 
-    //    @Bean
-//    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
-//        http
-//                .sessionManagement(session ->
-//                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-//                )
-//                .authorizeHttpRequests((requests) -> requests // HTTP 요청에 대한 접근 제어를 설정
-//                        .requestMatchers("/", "/home", "/signup", "/members/signup", "/css/**").permitAll() // 특정 URL 패턴에 대한 접근 권한을 설정
-//                        .requestMatchers("/admin/**").hasRole("ADMIN") // 'ADMIN' 역할을 가진 사용자만 접근 가능하도록 제한
-//                        .anyRequest().authenticated() // 그 외 모든 요청에 대해 인증을 요구
-//                )
-//                .formLogin((form) -> form
-//                        .loginPage("/login") // 커스텀 로그인 페이지를 /login 경로로 지정
-//                        .defaultSuccessUrl("/home", true) // 로그인 성공 시 /home으로 리다이렉트
-//                        .permitAll() // 로그인 페이지는 모든 사용자가 접근 가능하도록 설정
-//                )
-//                .logout((logout) -> logout
-//                        .logoutUrl("/logout") // /logout 경로로 로그아웃을 처리
-//                        .logoutSuccessUrl("/login?logout") // 로그아웃 성공 시 /login?logout으로 리다이렉트
-//                        .permitAll()
-//                );
-//
-//        return http.build();
-//    }
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package DNBN.spring.config.security;
 
+import DNBN.spring.apiPayload.exception.handler.CustomAuthenticationEntryPoint;
 import DNBN.spring.config.security.jwt.JwtAuthenticationFilter;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.service.OAuth2.CustomOAuth2UserService;
@@ -35,6 +36,7 @@ public class SecurityConfig {
     private final CustomOidcUserService customOidcUserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
+    private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() { // CORS 설정
@@ -109,6 +111,9 @@ public class SecurityConfig {
                         )
                         .successHandler(oAuth2SuccessHandler) // 온보딩 분기 등 커스텀 성공 핸들러
                         .failureHandler(oAuth2FailureHandler)
+                )
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
 

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -81,7 +81,6 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
 
         Member member = memberRepository.findBySocialId(socialId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.SOCIALID_NOT_FOUND));
-//                .orElseThrow(() -> new UsernameNotFoundException("User not found with socialId: " + socialId));
 
         MemberDetails memberDetails = new MemberDetails(member);
 

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -80,8 +80,8 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
         String socialId = claims.getSubject();
 
         Member member = memberRepository.findBySocialId(socialId)
-//                .orElseThrow(() -> new MemberHandler(ErrorStatus.SOCIALID_NOT_FOUND));
-                .orElseThrow(() -> new UsernameNotFoundException("User not found with socialId: " + socialId));
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.SOCIALID_NOT_FOUND));
+//                .orElseThrow(() -> new UsernameNotFoundException("User not found with socialId: " + socialId));
 
         MemberDetails memberDetails = new MemberDetails(member);
 

--- a/src/main/java/DNBN/spring/domain/Region.java
+++ b/src/main/java/DNBN/spring/domain/Region.java
@@ -23,7 +23,7 @@ public class Region extends BaseEntity {
     private String province; // ex: 서울
 
     @Column(length = 20, nullable = false)
-    private String city;     // ex: 강남구
+    private String city; // ex: 강남구
 
     @Column(length = 50, nullable = false)
     private String district; // ex: 개포1동

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2User.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2User.java
@@ -4,6 +4,9 @@ import DNBN.spring.domain.Member;
 import lombok.Getter;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 
 import java.util.Collection;
@@ -11,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @Getter
-public class CustomOAuth2User implements OAuth2User {
+public class CustomOAuth2User implements OAuth2User, OidcUser {
     private final Member member;
     private final Map<String, Object> attributes;
 
@@ -33,5 +36,20 @@ public class CustomOAuth2User implements OAuth2User {
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return List.of(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return attributes;
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return null; // 필요시 userRequest.getIdToken() 전달
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return null;
     }
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2User.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2User.java
@@ -45,7 +45,7 @@ public class CustomOAuth2User implements OAuth2User, OidcUser {
 
     @Override
     public OidcIdToken getIdToken() {
-        return null; // 필요시 userRequest.getIdToken() 전달
+        return null; // 필요시 userRequest.getIdToken() 전달, 우린 google에서 식별 가능한 값으로 sub를 받기 때문에 null 반환해도 정상적으로 동작함
     }
 
     @Override

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2UserService.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2UserService.java
@@ -25,38 +25,23 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
 
-        OAuth2User oAuth2User = super.loadUser(userRequest); // 소셜 API에서 사용자 정보 가져오기
+        OAuth2User oAuth2User = super.loadUser(userRequest); // 1. 소셜 API에서 사용자 정보 가져오기
 
-        // 2. provider 정보 (kakao, google, naver)
-        String provider = userRequest.getClientRegistration().getRegistrationId(); // "kakao", "google" 등
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // 2. provider 정보 (kakao, google, naver)
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oAuth2User.getAttributes());
         log.info("🌐 provider: {}, 🐤 attributes: {}, accessToken = {}", provider, oAuth2User.getAttributes(), userRequest.getAccessToken().getTokenValue());
 
         if (userInfo.getSocialId() == null) {
-//            throw new OAuth2AuthenticationException("소셜 로그인 ID가 없습니다.");
             throw new MemberHandler(ErrorStatus.INVALID_SOCIAL_TOKEN);
         }
 
-        // 3. 회원 조회 or 신규 회원 등록
         String checkSocialId = provider.toLowerCase() + "_" + userInfo.getSocialId();
         log.info("🔑 최종 socialId: {}", checkSocialId);
 
-//        Optional<Member> existing = memberRepository.findBySocialId(socialId);
-//        log.info("🔎 DB에 기존 회원 존재 여부: {}", existing.isPresent());
-//        Member member;
-//        if (existing.isPresent()) {
-//            member = existing.get();
-//            log.info("회원 로그인 성공: {}", SuccessStatus.MEMBER_LOGIN_SUCCESS.getMessage());
-//            // 필요시 기존 회원 업데이트 로직 추가 가능
-//        } else {
-//            member = saveNewMember(userInfo, provider);
-//            log.info("신규 회원 온보딩 필요: {}", SuccessStatus.MEMBER_NEEDS_ONBOARDING.getMessage());
-//        }
         Member member = memberRepository.findBySocialId(checkSocialId)
-                .orElseGet(() -> saveNewMember(userInfo, provider));
+                .orElseGet(() -> saveNewMember(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
-        // 4. 반환할 OAuth2User 구현체 (권한 부여용)
-        return new CustomOAuth2User(member, oAuth2User.getAttributes());
+        return new CustomOAuth2User(member, oAuth2User.getAttributes()); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
 //        return super.loadUser(userRequest);
     }
 
@@ -64,7 +49,6 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
         log.info("🆕 {} 신규 유저로 저장 시도", provider);
         String socialId = provider.toLowerCase() + "_" + userInfo.getSocialId(); // kakao_12345
         Member member = Member.builder()
-//                .socialId(userInfo.getSocialId())
                 .socialId(socialId)
                 .provider(Provider.from(provider))
                 .isOnboardingCompleted(false)

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2UserService.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOAuth2UserService.java
@@ -24,16 +24,13 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
 
     @Override
     public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        log.info("OAuth2 로그인 시도: clientRegistration = {}, accessToken = {}",
-                userRequest.getClientRegistration().getRegistrationId(),
-                userRequest.getAccessToken().getTokenValue());
 
         OAuth2User oAuth2User = super.loadUser(userRequest); // 소셜 API에서 사용자 정보 가져오기
 
         // 2. provider 정보 (kakao, google, naver)
         String provider = userRequest.getClientRegistration().getRegistrationId(); // "kakao", "google" 등
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oAuth2User.getAttributes());
-        log.info("🌐 provider: {}, 🐤 attributes: {}", provider, oAuth2User.getAttributes());
+        log.info("🌐 provider: {}, 🐤 attributes: {}, accessToken = {}", provider, oAuth2User.getAttributes(), userRequest.getAccessToken().getTokenValue());
 
         if (userInfo.getSocialId() == null) {
 //            throw new OAuth2AuthenticationException("소셜 로그인 ID가 없습니다.");
@@ -64,7 +61,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService { // Defau
     }
 
     private Member saveNewMember(OAuth2UserInfo userInfo, String provider) {
-        log.info("🆕 신규 유저로 저장 시도");
+        log.info("🆕 {} 신규 유저로 저장 시도", provider);
         String socialId = provider.toLowerCase() + "_" + userInfo.getSocialId(); // kakao_12345
         Member member = Member.builder()
 //                .socialId(userInfo.getSocialId())

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOidcUserService.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOidcUserService.java
@@ -1,0 +1,54 @@
+package DNBN.spring.service.OAuth2;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.enums.Provider;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService extends OidcUserService {
+    private final MemberRepository memberRepository;
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = super.loadUser(userRequest);
+
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+        OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oidcUser.getAttributes());
+        log.info("🌐 provider: {}, 🐤 attributes: {}, accessToken = {}", provider, oidcUser.getAttributes(), userRequest.getAccessToken().getTokenValue());
+
+        if (userInfo.getSocialId() == null) {
+            // 커스텀 예외 던지기
+            throw new MemberHandler(ErrorStatus.INVALID_SOCIAL_TOKEN);
+        }
+
+        String checkSocialId = provider.toLowerCase() + "_" + userInfo.getSocialId();
+        log.info("🔑 최종 socialId: {}", checkSocialId);
+
+        Member member = memberRepository.findBySocialId(checkSocialId)
+                .orElseGet(() -> saveNewMember(userInfo, provider));
+
+        return new CustomOAuth2User(member, oidcUser.getAttributes());
+    }
+
+    private Member saveNewMember(OAuth2UserInfo userInfo, String provider) {
+        log.info("🆕 {} 신규 유저로 저장 시도", provider);
+        String socialId = provider.toLowerCase() + "_" + userInfo.getSocialId();
+        Member member = Member.builder()
+                .socialId(socialId)
+                .provider(Provider.from(provider))
+                .isOnboardingCompleted(false)
+                .build();
+        return memberRepository.save(member);
+    }
+}

--- a/src/main/java/DNBN/spring/service/OAuth2/CustomOidcUserService.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/CustomOidcUserService.java
@@ -21,14 +21,14 @@ public class CustomOidcUserService extends OidcUserService {
 
     @Override
     public OidcUser loadUser(OidcUserRequest userRequest) throws OAuth2AuthenticationException {
-        OidcUser oidcUser = super.loadUser(userRequest);
 
-        String provider = userRequest.getClientRegistration().getRegistrationId();
+        OidcUser oidcUser = super.loadUser(userRequest);  // 1. 소셜 API에서 사용자 정보 가져오기
+
+        String provider = userRequest.getClientRegistration().getRegistrationId(); // 2. provider 정보 (kakao, google, naver)
         OAuth2UserInfo userInfo = OAuth2UserInfoFactory.getOAuth2UserInfo(provider, oidcUser.getAttributes());
         log.info("🌐 provider: {}, 🐤 attributes: {}, accessToken = {}", provider, oidcUser.getAttributes(), userRequest.getAccessToken().getTokenValue());
 
         if (userInfo.getSocialId() == null) {
-            // 커스텀 예외 던지기
             throw new MemberHandler(ErrorStatus.INVALID_SOCIAL_TOKEN);
         }
 
@@ -36,9 +36,9 @@ public class CustomOidcUserService extends OidcUserService {
         log.info("🔑 최종 socialId: {}", checkSocialId);
 
         Member member = memberRepository.findBySocialId(checkSocialId)
-                .orElseGet(() -> saveNewMember(userInfo, provider));
+                .orElseGet(() -> saveNewMember(userInfo, provider)); // 3. 회원 조회 or 신규 회원 등록
 
-        return new CustomOAuth2User(member, oidcUser.getAttributes());
+        return new CustomOAuth2User(member, oidcUser.getAttributes()); // 4. 반환할 OAuth2User 구현체 (권한 부여용)
     }
 
     private Member saveNewMember(OAuth2UserInfo userInfo, String provider) {

--- a/src/main/java/DNBN/spring/service/OAuth2/GoogleUserInfo.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/GoogleUserInfo.java
@@ -1,0 +1,14 @@
+package DNBN.spring.service.OAuth2;
+
+import java.util.Map;
+
+public class GoogleUserInfo extends OAuth2UserInfo {
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        super(attributes);
+    }
+
+    @Override
+    public String getSocialId() {
+        return attributes.get("sub").toString();
+    }
+}

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -36,23 +36,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         log.info("🔐 authentication.getPrincipal() 타입: {}", authentication.getPrincipal().getClass().getName());
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
-//        Object principal = authentication.getPrincipal();
-
-        // ✅ CustomOAuth2User 타입이 아니면 예외 던지기
-//        if (!(principal instanceof CustomOAuth2User)) {
-//            throw new OAuth2AuthenticationException(
-//                    "Expected CustomOAuth2User but got " + principal.getClass().getName()
-//            );
-//        }
-//
-//        CustomOAuth2User oAuth2User = (CustomOAuth2User) principal; // 이제 안전하게 다운캐스팅
 
         Member member = oAuth2User.getMember();
         log.info("🙋‍♂️ 로그인한 유저 ID: {}, 온보딩 여부: {}", member.getId(), member.isOnboardingCompleted());
 
         // JWT 발급
-//        String accessToken = jwtTokenProvider.generateAccessToken(member.getSocialId()); // kakao_12345
-        String accessToken = jwtTokenProvider.generateAccessToken(authentication); // subject = socialId
+        String accessToken = jwtTokenProvider.generateAccessToken(authentication); // kakao_12345
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getSocialId());
 
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -13,6 +13,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 
@@ -26,7 +27,6 @@ import java.nio.charset.StandardCharsets;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
-    private final MemberRepository memberRepository;
     private final ObjectMapper objectMapper;
 
     @Override
@@ -36,6 +36,17 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         log.info("🔐 authentication.getPrincipal() 타입: {}", authentication.getPrincipal().getClass().getName());
 
         CustomOAuth2User oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+//        Object principal = authentication.getPrincipal();
+
+        // ✅ CustomOAuth2User 타입이 아니면 예외 던지기
+//        if (!(principal instanceof CustomOAuth2User)) {
+//            throw new OAuth2AuthenticationException(
+//                    "Expected CustomOAuth2User but got " + principal.getClass().getName()
+//            );
+//        }
+//
+//        CustomOAuth2User oAuth2User = (CustomOAuth2User) principal; // 이제 안전하게 다운캐스팅
+
         Member member = oAuth2User.getMember();
         log.info("🙋‍♂️ 로그인한 유저 ID: {}, 온보딩 여부: {}", member.getId(), member.isOnboardingCompleted());
 

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2UserInfoFactory.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2UserInfoFactory.java
@@ -9,7 +9,7 @@ public class OAuth2UserInfoFactory {
         return switch (provider.toLowerCase()) {
             case "kakao" -> new KakaoUserInfo(attributes);
             case "naver" -> new NaverUserInfo((Map<String, Object>) attributes.get("response"));
-            // case "google" -> new GoogleUserInfo(attributes);
+            case "google" -> new GoogleUserInfo(attributes);
             default -> throw new OAuth2AuthenticationException("지원하지 않는 소셜 로그인입니다.");
         };
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,6 +41,15 @@ spring:
             authorization-grant-type: authorization_code
             scope:
             client-name: Naver
+          google:
+            client-authentication-method: client_secret_post
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_SECRET}
+            redirect-uri: ${GOOGLE_REDIRECT_URL}
+            authorization-grant-type: authorization_code
+            scope:
+              - openid
+            client-name: Google
         provider:
           kakao:
             authorization-uri: https://kauth.kakao.com/oauth/authorize
@@ -52,6 +61,11 @@ spring:
             token-uri: https://nid.naver.com/oauth2.0/token
             user-info-uri: https://openapi.naver.com/v1/nid/me
             user-name-attribute: response
+          google:
+            authorization-uri: https://accounts.google.com/o/oauth2/v2/auth
+            token-uri: https://oauth2.googleapis.com/token
+            user-info-uri: https://www.googleapis.com/oauth2/v3/userinfo
+            user-name-attribute: sub
 jwt:
   token:
     secretKey: ${JWT_SECRETKEY}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 구글 소셜 로그인 구현 -> CustomOAuth2UserService로 카카오/네이버/구글 모두 사용하고 싶었는데, 구글은 반환값이 달라서 CustomOidcUserService 만들었음
- [x] 만료된 access token 넣었을 때 응답 처리
- [x] 불필요한 코드 삭제
- [x] 주석에 설명 추가
- [x] 리팩토링

## 📸 스크린샷 (선택)
소셜 로그인 중...
<img width="890" height="420" alt="image" src="https://github.com/user-attachments/assets/35b8004a-ea96-43b0-a1a0-51ac4d4d6d6e" />

온보딩
<img width="403" height="311" alt="image" src="https://github.com/user-attachments/assets/77d19631-540f-44ed-bae8-b54c91961619" />
정보 조회
<img width="913" height="439" alt="image" src="https://github.com/user-attachments/assets/fe123420-e929-42b2-959f-9152fdf7d131" />
만료된 어세스 토큰 넣었을 때
<img width="520" height="287" alt="image" src="https://github.com/user-attachments/assets/d5745532-9742-45fd-b745-6122a6ff13ec" />


## 💬 기타(공유사항 to 리뷰어)
- 브랜치 삭제하지 말아주세요

- 성공, 실패 핸들러의 반환은 프론트에서 브릿지 페이지 전달받으면 쿠키로 내려줄 예정

(이 아래의 테스트 이미 다 해보긴 했는데 리뷰어 계정으로도 테스트 꼭 차례대로 해주세요!
아래에 1~12 다 해보긴 했는데 전부 사진 캡쳐는 못 했고
암튼 리뷰어가 다시 전부 확인 부탁합니다.
제 계정이라서 된 거일 수도 있으니..)

- 아래 차례대로 부탁해요

리뷰어는 feat/genie/25 체크아웃해서(코드는 절대 수정 X)
인텔리제이 run하고
각 소셜 로그인 테스트해주세요
(네이버는 검수받기 전까지 안 될 가능성 높으니 네이버id 저한테 전달해주시면 테스트id로 넣어드릴게요)

아래는 차례대로 카카오/네이버/구글 소셜 로그인 접속 링크
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google
(카카오/네이버/구글 셋 다 각각 1~12 해주세요!)

위에서 소셜로그인으로 받은 어세스 토큰 스웨거에 넣고 테스트 시작

**에러 발생 시 스웨거 캡쳐랑 인텔리제이 로그 복붙 카톡으로 공유 부탁합니다**

1. 소셜 로그인한 직후 회원 정보 조회 **(이때 어세스 토큰 메모장에 적어주세요)**
2. 온보딩(닉네임 null로)
3. 온보딩(닉네임 넣고 chosenRegionIds에 아무것도 안 적고)->1개 미만
4. 온보딩(닉네임 넣고 chosenRegionIds에 0만 적고)->없는 값
5. 온보딩(chosenRegionIds에 0,1 넣고)->없는 값 포함
6. 온보딩(chosenRegionIds에 1,2,3,4 이렇게 3개 초과로 넣고)->3개 초과
7. 온보딩(닉네임, 좋아하는 동네, 프로필 사진까지 다 넣고)->정상
8. 7번 후에 다시 회원 정보 조회하고 반환된 profileImage값을 새 탭에 입력했을 때 넣은 프로필 보이는지 확인
9. 탈퇴 후 **1번에서 메모장에 적었던 에세스 토큰 넣고** 멤버 조회했을 때 결과 위에 캡쳐 사진과 같은지 확인
10. 탈퇴 후 다시 소셜 로그인 해보기
11. 탈퇴 후 2~7번 해보기
12. 뭐 나머지 하고 싶은 테스트 해주세요