### PR TITLE
✨[Feat] 카테고리 목록 조회/추가/수정/삭제 구현

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -55,7 +55,9 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_INVALID_NAME(HttpStatus.BAD_REQUEST, "CATEGORY_400_INVALID_NAME", "카테고리 이름이 유효하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_404_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
     CATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, "CATEGORY_409_DUPLICATE_NAME", "이미 존재하는 카테고리 이름입니다."),
-    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다.");
+    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다."),
+
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "해당 장소를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -40,8 +40,22 @@ public enum ErrorStatus implements BaseErrorCode {
 
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "유효하지 않은 SocialToken입니다."),
 
-    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다.");
+    INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
 
+    //like
+    POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시물을 찾을 수 없습니다."),
+    ALREADY_LIKED(HttpStatus.CONFLICT, "LIKE4001", "이미 좋아요를 누르셨습니다."),
+    NOT_LIKED(HttpStatus.NOT_FOUND, "LIKE4002", "좋아요를 누르지 않았거나, 해당 게시물을 찾을 수 없습니다."),
+
+    //spam
+    ALREADY_SPAM_REPORTED(HttpStatus.CONFLICT, "SPAM4001", "이미 광고 의심 신고를 하셨습니다."),
+    NOT_SPAM_REPORTED(HttpStatus.NOT_FOUND, "SPAM4002", "광고 의심 신고를 하지 않았거나, 해당 게시물을 찾을 수 없습니다."),
+
+    //category
+    CATEGORY_INVALID_NAME(HttpStatus.BAD_REQUEST, "CATEGORY_400_INVALID_NAME", "카테고리 이름이 유효하지 않습니다."),
+    CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_404_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
+    CATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, "CATEGORY_409_DUPLICATE_NAME", "이미 존재하는 카테고리 이름입니다."),
+    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/DNBN/spring/apiPayload/exception/DuplicateCategoryException.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/DuplicateCategoryException.java
@@ -1,0 +1,7 @@
+package DNBN.spring.apiPayload.exception;
+
+public class DuplicateCategoryException extends RuntimeException {
+    public DuplicateCategoryException() {
+        super("이미 존재하는 카테고리 이름입니다.");
+    }
+}

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CategoryHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CategoryHandler.java
@@ -1,0 +1,10 @@
+package DNBN.spring.apiPayload.exception.handler;
+
+import DNBN.spring.apiPayload.code.BaseErrorCode;
+import DNBN.spring.apiPayload.exception.GeneralException;
+
+public class CategoryHandler extends GeneralException {
+    public CategoryHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -51,4 +51,5 @@ public class Article extends BaseEntity {
   private Long spamCount = 0L;
 
   private LocalDateTime deletedAt;
+
 }

--- a/src/main/java/DNBN/spring/domain/ArticleLike.java
+++ b/src/main/java/DNBN/spring/domain/ArticleLike.java
@@ -1,0 +1,28 @@
+package DNBN.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article_like", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"article_id", "member_id"})
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArticleLike {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long articleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+}
+

--- a/src/main/java/DNBN/spring/domain/ArticleLike.java
+++ b/src/main/java/DNBN/spring/domain/ArticleLike.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "article_like", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"article_id", "member_id"})
@@ -15,14 +17,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ArticleLike {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long articleId;
+
+    @EmbeddedId
+    private ArticleLikeId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("articleId")
+    @JoinColumn(name = "article_id")
     private Article article;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("memberId")
+    @JoinColumn(name = "member_id")
     private Member member;
+
+    @Column(name = "created_at", nullable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
 }
 

--- a/src/main/java/DNBN/spring/domain/ArticleLike.java
+++ b/src/main/java/DNBN/spring/domain/ArticleLike.java
@@ -33,5 +33,22 @@ public class ArticleLike {
 
     @Column(name = "created_at", nullable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
     private LocalDateTime createdAt;
+
+    @PrePersist
+    public void prePersist() {
+        if (this.id == null && this.article != null && this.member != null) {
+            this.id = new ArticleLikeId(article.getArticleId(), member.getId());
+        }
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+    public static ArticleLike of(Article article, Member member) {
+        return ArticleLike.builder()
+                .article(article)
+                .member(member)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }
 

--- a/src/main/java/DNBN/spring/domain/ArticleLikeId.java
+++ b/src/main/java/DNBN/spring/domain/ArticleLikeId.java
@@ -1,0 +1,17 @@
+package DNBN.spring.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+public class ArticleLikeId implements Serializable {
+    private Long articleId;
+    private Long memberId;
+}

--- a/src/main/java/DNBN/spring/domain/ArticleSpam.java
+++ b/src/main/java/DNBN/spring/domain/ArticleSpam.java
@@ -6,6 +6,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "article_spam", uniqueConstraints = {
         @UniqueConstraint(columnNames = {"article_id", "member_id"})
@@ -15,13 +17,52 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Builder
 public class ArticleSpam {
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long articleId;
+
+    @EmbeddedId
+    private ArticleSpamId id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("articleId")
+    @JoinColumn(name = "article_id")
     private Article article;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @MapsId("memberId")
+    @JoinColumn(name = "member_id")
     private Member member;
+
+    @Column(name = "created_at", nullable = false, columnDefinition = "DATETIME DEFAULT CURRENT_TIMESTAMP")
+    private LocalDateTime createdAt;
+
+//    @PrePersist
+//    public void prePersist() {
+//        if (this.id == null && this.article != null && this.member != null) {
+//            this.id = new ArticleSpamId(article.getArticleId(), member.getId());
+//        }
+//        if (this.createdAt == null) {
+//            this.createdAt = LocalDateTime.now();
+//        }
+//    }
+//    public static ArticleSpam of(Article article, Member member) {
+//        return ArticleSpam.builder()
+//                .article(article)
+//                .member(member)
+//                .createdAt(LocalDateTime.now())
+//                .build();
+//    }
+    @PrePersist
+    public void prePersist() {
+        if (this.createdAt == null) {
+            this.createdAt = LocalDateTime.now();
+        }
+    }
+
+    public static ArticleSpam of(Article article, Member member) {
+        return ArticleSpam.builder()
+                .id(new ArticleSpamId(article.getArticleId(), member.getId()))
+                .article(article)
+                .member(member)
+                .createdAt(LocalDateTime.now())
+                .build();
+    }
 }

--- a/src/main/java/DNBN/spring/domain/ArticleSpam.java
+++ b/src/main/java/DNBN/spring/domain/ArticleSpam.java
@@ -1,0 +1,27 @@
+package DNBN.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "article_spam", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"article_id", "member_id"})
+})
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class ArticleSpam {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long articleId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Article article;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+}

--- a/src/main/java/DNBN/spring/domain/ArticleSpamId.java
+++ b/src/main/java/DNBN/spring/domain/ArticleSpamId.java
@@ -1,0 +1,17 @@
+package DNBN.spring.domain;
+
+import jakarta.persistence.Embeddable;
+import lombok.*;
+
+import java.io.Serializable;
+
+@Embeddable
+@Getter
+@Setter
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+public class ArticleSpamId implements Serializable {
+    private Long articleId;
+    private Long memberId;
+}

--- a/src/main/java/DNBN/spring/domain/Category.java
+++ b/src/main/java/DNBN/spring/domain/Category.java
@@ -46,7 +46,7 @@ public class Category extends BaseEntity {
   @Enumerated(EnumType.STRING)
   @Column(nullable = false, length = 10)
   private Color color;
-
+  @Column(name = "deleted_at")
   private LocalDateTime deletedAt;
 
   @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
@@ -56,7 +56,7 @@ public class Category extends BaseEntity {
     this.name = name;
     this.color = color;
   }
-
+  @PreRemove
   public void softDelete() {
     this.deletedAt = LocalDateTime.now();
   }

--- a/src/main/java/DNBN/spring/domain/Category.java
+++ b/src/main/java/DNBN/spring/domain/Category.java
@@ -51,4 +51,13 @@ public class Category extends BaseEntity {
 
   @OneToMany(mappedBy = "category", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<SavePlace> savedPlaces = new ArrayList<>();
+
+  public void update(String name, Color color) {
+    this.name = name;
+    this.color = color;
+  }
+
+  public void softDelete() {
+    this.deletedAt = LocalDateTime.now();
+  }
 }

--- a/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
@@ -1,0 +1,12 @@
+package DNBN.spring.repository.ArticleLikeRepository;
+
+import DNBN.spring.domain.ArticleLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
+    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
+    Optional<ArticleLike> findByArticleIdAndMemberId(Long articleId, Long memberId);
+    long countByArticleId(Long articleId);
+}

--- a/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
@@ -1,12 +1,19 @@
 package DNBN.spring.repository.ArticleLikeRepository;
 
+import DNBN.spring.domain.Article;
 import DNBN.spring.domain.ArticleLike;
+import DNBN.spring.domain.ArticleLikeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> {
-    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
-    Optional<ArticleLike> findByArticleIdAndMemberId(Long articleId, Long memberId);
-    long countByArticleId(Long articleId);
+//    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
+//    Optional<ArticleLike> findByArticleIdAndMemberId(Long articleId, Long memberId);
+//    long countByArticleId(Long articleId);
+    boolean existsById(ArticleLikeId id);
+
+    Optional<ArticleLike> findById(ArticleLikeId id);
+
+    long countByArticle(Article article);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleLikeRepository/ArticleLikeRepository.java
@@ -14,6 +14,5 @@ public interface ArticleLikeRepository extends JpaRepository<ArticleLike, Long> 
     boolean existsById(ArticleLikeId id);
 
     Optional<ArticleLike> findById(ArticleLikeId id);
-
-    long countByArticle(Article article);
+    long countByArticle_ArticleId(Long articleId);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleSpamRepository/ArticleSpamRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleSpamRepository/ArticleSpamRepository.java
@@ -1,12 +1,14 @@
 package DNBN.spring.repository.ArticleSpamRepository;
 
 import DNBN.spring.domain.ArticleSpam;
+import DNBN.spring.domain.ArticleSpamId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ArticleSpamRepository extends JpaRepository<ArticleSpam, Long> {
-    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
-    Optional<ArticleSpam> findByArticleIdAndMemberId(Long articleId, Long memberId);
-    long countByArticleId(Long articleId);
+public interface ArticleSpamRepository extends JpaRepository<ArticleSpam, ArticleSpamId> {
+    boolean existsById(ArticleSpamId id);
+    //boolean existsByArticle_ArticleIdAndMember_Id(Long articleId, Long memberId);
+    Optional<ArticleSpam> findByArticle_ArticleIdAndMember_Id(Long articleId, Long memberId);
+    long countByArticle_ArticleId(Long articleId);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleSpamRepository/ArticleSpamRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleSpamRepository/ArticleSpamRepository.java
@@ -1,0 +1,12 @@
+package DNBN.spring.repository.ArticleSpamRepository;
+
+import DNBN.spring.domain.ArticleSpam;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface ArticleSpamRepository extends JpaRepository<ArticleSpam, Long> {
+    boolean existsByArticleIdAndMemberId(Long articleId, Long memberId);
+    Optional<ArticleSpam> findByArticleIdAndMemberId(Long articleId, Long memberId);
+    long countByArticleId(Long articleId);
+}

--- a/src/main/java/DNBN/spring/repository/CategoryRepository/CategoryRepository.java
+++ b/src/main/java/DNBN/spring/repository/CategoryRepository/CategoryRepository.java
@@ -6,10 +6,14 @@ import DNBN.spring.domain.Place;
 import DNBN.spring.domain.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
-    List<Category> findAllByMember(Member member);
-    List<Category> findAllByPlace(Place place);
-    List<Category> findAllByRegion(Region region);
+//    List<Category> findAllByMember(Member member);
+//    List<Category> findAllByPlace(Place place);
+//    List<Category> findAllByRegion(Region region);
+    boolean existsByNameAndMemberAndDeletedAtIsNull(String name, Member member);
+    Optional<Category> findByCategoryIdAndMemberAndDeletedAtIsNull(Long categoryId, Member member);
+    List<Category> findAllByMemberAndDeletedAtIsNull(Member member);
 }
 

--- a/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
@@ -1,0 +1,18 @@
+package DNBN.spring.service.ArticleLikeService;
+
+import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
+import DNBN.spring.web.dto.LikeStatusResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleLikeQueryService {
+
+    private final ArticleLikeRepository articleLikeRepository;
+
+    public LikeStatusResponseDTO getLikeStatus(Long articleId, Long memberId) {
+        boolean exists = articleLikeRepository.existsByArticleIdAndMemberId(articleId, memberId);
+        return new LikeStatusResponseDTO(exists);
+    }
+}

--- a/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
@@ -13,8 +13,8 @@ public class ArticleLikeQueryService {
     private final ArticleLikeRepository articleLikeRepository;
 
     public LikeStatusResponseDTO getLikeStatus(Long articleId, Long memberId) {
-        ArticleLikeId likeId = new ArticleLikeId(articleId, memberId);
-        boolean exists = articleLikeRepository.existsById(likeId);
-        return new LikeStatusResponseDTO(exists);
+        long likesCount = articleLikeRepository.countByArticle_ArticleId(articleId);
+
+        return new LikeStatusResponseDTO(articleId, likesCount);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeQueryService.java
@@ -1,5 +1,6 @@
 package DNBN.spring.service.ArticleLikeService;
 
+import DNBN.spring.domain.ArticleLikeId;
 import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
 import DNBN.spring.web.dto.LikeStatusResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -12,7 +13,8 @@ public class ArticleLikeQueryService {
     private final ArticleLikeRepository articleLikeRepository;
 
     public LikeStatusResponseDTO getLikeStatus(Long articleId, Long memberId) {
-        boolean exists = articleLikeRepository.existsByArticleIdAndMemberId(articleId, memberId);
+        ArticleLikeId likeId = new ArticleLikeId(articleId, memberId);
+        boolean exists = articleLikeRepository.existsById(likeId);
         return new LikeStatusResponseDTO(exists);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeService.java
+++ b/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeService.java
@@ -12,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import static DNBN.spring.domain.QArticle.article;
+import static DNBN.spring.domain.QMember.member;
+import static org.springframework.data.jpa.domain.AbstractPersistable_.id;
 
 @Service
 @RequiredArgsConstructor
@@ -29,17 +31,17 @@ public class ArticleLikeService {
         if (articleLikeRepository.existsById(likeId)) {
             throw new GeneralException(ErrorStatus.ALREADY_LIKED);
         }
-
+        ArticleLikeId id = new ArticleLikeId(article.getArticleId(), memberId);
         ArticleLike articleLike = ArticleLike.builder()
+                .id(id)
                 .article(article)
                 .member(memberRepository.getReferenceById(memberId))
                 .build();
 
         articleLikeRepository.save(articleLike);
 
-        long likesCount = articleLikeRepository.countByArticle(article);
-        long spamCount = 0;
-        return LikeResponseDTO.of(articleId, likesCount, spamCount);
+        long likesCount = articleLikeRepository.countByArticle_ArticleId(articleId);
+        return LikeResponseDTO.of(articleId, likesCount);
     }
 
     public LikeResponseDTO unlikeArticle(Long articleId, Long memberId) {
@@ -49,8 +51,7 @@ public class ArticleLikeService {
 
         articleLikeRepository.delete(articleLike);
         Article article = articleLike.getArticle();
-        long likesCount = articleLikeRepository.countByArticle(article);
-        long spamCount = 0;
-        return LikeResponseDTO.of(articleId, likesCount, spamCount);
+        long likesCount = articleLikeRepository.countByArticle_ArticleId(articleId);
+        return LikeResponseDTO.of(articleId, likesCount);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeService.java
+++ b/src/main/java/DNBN/spring/service/ArticleLikeService/ArticleLikeService.java
@@ -1,0 +1,49 @@
+package DNBN.spring.service.ArticleLikeService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.GeneralException;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.ArticleLike;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.web.dto.LikeResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleLikeService {
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+    private final DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository articleLikeRepository;
+
+    public LikeResponseDTO likeArticle(Long articleId, Long memberId) {
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+
+        if (articleLikeRepository.existsByArticleIdAndMemberId(articleId, memberId)) {
+            throw new GeneralException(ErrorStatus.ALREADY_LIKED);
+        }
+
+        ArticleLike articleLike = ArticleLike.builder()
+                .article(article)
+                .member(memberRepository.getReferenceById(memberId))
+                .build();
+
+        articleLikeRepository.save(articleLike);
+
+        long likesCount = articleLikeRepository.countByArticleId(articleId);
+        long spamCount = 0;
+        return LikeResponseDTO.of(articleId, likesCount, spamCount);
+    }
+
+    public LikeResponseDTO unlikeArticle(Long articleId, Long memberId) {
+        ArticleLike articleLike = articleLikeRepository.findByArticleIdAndMemberId(articleId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_LIKED));
+
+        articleLikeRepository.delete(articleLike);
+        long likesCount = articleLikeRepository.countByArticleId(articleId);
+        long spamCount = 0;
+        return LikeResponseDTO.of(articleId, likesCount, spamCount);
+    }
+}

--- a/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamQueryService.java
@@ -1,0 +1,18 @@
+package DNBN.spring.service.ArticleSpamService;
+
+import DNBN.spring.repository.ArticleSpamRepository.ArticleSpamRepository;
+import DNBN.spring.web.dto.SpamStatusResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleSpamQueryService {
+
+    private final ArticleSpamRepository articleSpamRepository;
+
+    public SpamStatusResponseDTO getSpamStatus(Long articleId, Long memberId) {
+        boolean exists = articleSpamRepository.existsByArticleIdAndMemberId(articleId, memberId);
+        return new SpamStatusResponseDTO(exists);
+    }
+}

--- a/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamQueryService.java
@@ -1,6 +1,8 @@
 package DNBN.spring.service.ArticleSpamService;
 
+import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
 import DNBN.spring.repository.ArticleSpamRepository.ArticleSpamRepository;
+import DNBN.spring.web.dto.LikeStatusResponseDTO;
 import DNBN.spring.web.dto.SpamStatusResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -12,7 +14,8 @@ public class ArticleSpamQueryService {
     private final ArticleSpamRepository articleSpamRepository;
 
     public SpamStatusResponseDTO getSpamStatus(Long articleId, Long memberId) {
-        boolean exists = articleSpamRepository.existsByArticleIdAndMemberId(articleId, memberId);
-        return new SpamStatusResponseDTO(exists);
+        long spamsCount = articleSpamRepository.countByArticle_ArticleId(articleId);
+
+        return new SpamStatusResponseDTO(articleId, spamsCount);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamService.java
+++ b/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamService.java
@@ -4,11 +4,15 @@ import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.GeneralException;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.ArticleSpam;
+import DNBN.spring.domain.ArticleSpamId;
+import DNBN.spring.domain.Member;
 import DNBN.spring.repository.ArticleRepository.ArticleRepository;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.web.dto.SpamResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import static DNBN.spring.domain.QMember.member;
 
 @Service
 @RequiredArgsConstructor
@@ -20,30 +24,33 @@ public class ArticleSpamService {
     public SpamResponseDTO spamArticle(Long articleId, Long memberId) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.MEMBER_NOT_FOUND));
 
-        if (articleSpamRepository.existsByArticleIdAndMemberId(articleId, memberId)) {
-            throw new GeneralException(ErrorStatus.ALREADY_LIKED);
+        ArticleSpamId spamId = new ArticleSpamId(articleId, memberId);
+
+        if (articleSpamRepository.existsById(spamId)) {
+            throw new GeneralException(ErrorStatus.ALREADY_SPAM_REPORTED);
         }
 
-        ArticleSpam articleSpam = ArticleSpam.builder()
-                .article(article)
-                .member(memberRepository.getReferenceById(memberId))
-                .build();
+//        ArticleSpam articleSpam = ArticleSpam.builder()
+//                .article(article)
+//                .member(memberRepository.getReferenceById(memberId))
+//                .build();
 
+        ArticleSpam articleSpam = ArticleSpam.of(article, member);
         articleSpamRepository.save(articleSpam);
 
-        long spamsCount = articleSpamRepository.countByArticleId(articleId);
-        long spamCount = 0;
-        return SpamResponseDTO.of(articleId, spamsCount, spamCount);
+        long spamsCount = articleSpamRepository.countByArticle_ArticleId(articleId);
+        return SpamResponseDTO.of(articleId, spamsCount);
     }
 
     public SpamResponseDTO unspamArticle(Long articleId, Long memberId) {
-        ArticleSpam articleSpam = articleSpamRepository.findByArticleIdAndMemberId(articleId, memberId)
-                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_LIKED));
+        ArticleSpam articleSpam = articleSpamRepository.findByArticle_ArticleIdAndMember_Id(articleId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_SPAM_REPORTED));
 
         articleSpamRepository.delete(articleSpam);
-        long spamsCount = articleSpamRepository.countByArticleId(articleId);
-        long spamCount = 0;
-        return SpamResponseDTO.of(articleId, spamsCount, spamCount);
+        long spamsCount = articleSpamRepository.countByArticle_ArticleId(articleId);
+        return SpamResponseDTO.of(articleId, spamsCount);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamService.java
+++ b/src/main/java/DNBN/spring/service/ArticleSpamService/ArticleSpamService.java
@@ -1,0 +1,49 @@
+package DNBN.spring.service.ArticleSpamService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.GeneralException;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.ArticleSpam;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.web.dto.SpamResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ArticleSpamService {
+    private final ArticleRepository articleRepository;
+    private final MemberRepository memberRepository;
+    private final DNBN.spring.repository.ArticleSpamRepository.ArticleSpamRepository articleSpamRepository;
+
+    public SpamResponseDTO spamArticle(Long articleId, Long memberId) {
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.ARTICLE_NOT_FOUND));
+
+        if (articleSpamRepository.existsByArticleIdAndMemberId(articleId, memberId)) {
+            throw new GeneralException(ErrorStatus.ALREADY_LIKED);
+        }
+
+        ArticleSpam articleSpam = ArticleSpam.builder()
+                .article(article)
+                .member(memberRepository.getReferenceById(memberId))
+                .build();
+
+        articleSpamRepository.save(articleSpam);
+
+        long spamsCount = articleSpamRepository.countByArticleId(articleId);
+        long spamCount = 0;
+        return SpamResponseDTO.of(articleId, spamsCount, spamCount);
+    }
+
+    public SpamResponseDTO unspamArticle(Long articleId, Long memberId) {
+        ArticleSpam articleSpam = articleSpamRepository.findByArticleIdAndMemberId(articleId, memberId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_LIKED));
+
+        articleSpamRepository.delete(articleSpam);
+        long spamsCount = articleSpamRepository.countByArticleId(articleId);
+        long spamCount = 0;
+        return SpamResponseDTO.of(articleId, spamsCount, spamCount);
+    }
+}

--- a/src/main/java/DNBN/spring/service/CategoryService/CategoryQueryService.java
+++ b/src/main/java/DNBN/spring/service/CategoryService/CategoryQueryService.java
@@ -1,0 +1,27 @@
+package DNBN.spring.service.CategoryService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
+import DNBN.spring.domain.Member;
+import DNBN.spring.repository.CategoryRepository.CategoryRepository;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.web.dto.CategoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryQueryService {
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+
+    public List<CategoryResponseDTO> getMyCategories(Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        return categoryRepository.findAllByMemberAndDeletedAtIsNull(member).stream()
+                .map(c -> new CategoryResponseDTO(c.getCategoryId(), c.getName(), c.getColor().name()))
+                .toList();
+    }
+}

--- a/src/main/java/DNBN/spring/service/CategoryService/CategoryService.java
+++ b/src/main/java/DNBN/spring/service/CategoryService/CategoryService.java
@@ -1,0 +1,61 @@
+package DNBN.spring.service.CategoryService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.DuplicateCategoryException;
+import DNBN.spring.apiPayload.exception.handler.CategoryHandler;
+import DNBN.spring.domain.Category;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.enums.Color;
+import DNBN.spring.repository.CategoryRepository.CategoryRepository;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.web.dto.CategoryRequestDTO;
+import DNBN.spring.web.dto.CategoryResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+    private final MemberRepository memberRepository;
+
+    public CategoryResponseDTO create(Long memberId, CategoryRequestDTO dto) {
+        Member member = getMember(memberId);
+        if (categoryRepository.existsByNameAndMemberAndDeletedAtIsNull(dto.name(), member)) {
+            throw new CategoryHandler(ErrorStatus.CATEGORY_DUPLICATE_NAME);
+        }
+
+        Category category = Category.builder()
+                .name(dto.name())
+                .color(Color.from(dto.color()))
+                .member(member)
+                .place(null)
+                .region(null)
+                .build();
+
+        categoryRepository.save(category);
+        return new CategoryResponseDTO(category.getCategoryId(), category.getName(), category.getColor().name());
+    }
+
+    public CategoryResponseDTO update(Long memberId, Long categoryId, CategoryRequestDTO dto) {
+        Category category = getOwnedCategory(memberId, categoryId);
+        category.update(dto.name(), Color.from(dto.color()));
+        return new CategoryResponseDTO(category.getCategoryId(), category.getName(), category.getColor().name());
+    }
+
+    public void delete(Long memberId, Long categoryId) {
+        Category category = getOwnedCategory(memberId, categoryId);
+        // 게시글 연결 여부 확인하고 예외 던질 수 있음
+        category.softDelete();
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId).orElseThrow(() -> new CategoryHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    private Category getOwnedCategory(Long memberId, Long categoryId) {
+        Member member = getMember(memberId);
+        return categoryRepository.findByCategoryIdAndMemberAndDeletedAtIsNull(categoryId, member)
+                .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+    }
+}

--- a/src/main/java/DNBN/spring/service/CategoryService/CategoryService.java
+++ b/src/main/java/DNBN/spring/service/CategoryService/CategoryService.java
@@ -14,11 +14,13 @@ import DNBN.spring.repository.PlaceRepository.PlaceRepository;
 import DNBN.spring.repository.RegionRepository.RegionRepository;
 import DNBN.spring.web.dto.CategoryRequestDTO;
 import DNBN.spring.web.dto.CategoryResponseDTO;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CategoryService {
     private final PlaceRepository placeRepository;
     private final RegionRepository regionRepository;
@@ -64,7 +66,6 @@ public class CategoryService {
 
     public void delete(Long memberId, Long categoryId) {
         Category category = getOwnedCategory(memberId, categoryId);
-        // 게시글 연결 여부 확인하고 예외 던질 수 있음
         category.softDelete();
     }
 

--- a/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
@@ -1,0 +1,69 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
+import DNBN.spring.config.security.jwt.JwtTokenProvider;
+import DNBN.spring.domain.Member;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.service.ArticleLikeService.ArticleLikeService;
+import DNBN.spring.web.dto.AuthResponseDTO;
+import DNBN.spring.web.dto.LikeResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@SecurityRequirement(name = "JWT TOKEN")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/articles")
+public class ArticleLikeController {
+
+    private final ArticleLikeService articleLikeService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+
+    @Operation(
+            summary = "좋아요 등록",
+            description = "좋아요가 성공적으로 등록되었습니다."
+    )
+    @PostMapping("/{articleId}/likes")
+    public ResponseEntity<ApiResponse<LikeResponseDTO>> likeArticle(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        LikeResponseDTO response = articleLikeService.likeArticle(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(
+            summary = "좋아요 취소",
+            description = "좋아요가 성공적으로 취소되었습니다."
+    )
+    @DeleteMapping("/{articleId}/likes")
+    public ResponseEntity<ApiResponse<LikeResponseDTO>> unlikeArticle(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        LikeResponseDTO response = articleLikeService.unlikeArticle(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+
+    private Long extractMemberIdFromToken(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        String socialId = jwtTokenProvider.getSubjectFromToken(token);
+        return memberRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND))
+                .getId();
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "JWT TOKEN")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles")
+@RequestMapping("/api/articles")
 public class ArticleLikeController {
 
     private final ArticleLikeService articleLikeService;

--- a/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleLikeController.java
@@ -6,9 +6,11 @@ import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.service.ArticleLikeService.ArticleLikeQueryService;
 import DNBN.spring.service.ArticleLikeService.ArticleLikeService;
 import DNBN.spring.web.dto.AuthResponseDTO;
 import DNBN.spring.web.dto.LikeResponseDTO;
+import DNBN.spring.web.dto.LikeStatusResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
@@ -25,11 +27,25 @@ public class ArticleLikeController {
     private final ArticleLikeService articleLikeService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final ArticleLikeQueryService articleLikeQueryService;
 
+    @Operation(
+            summary = "좋아요 여부 조회",
+            description = "해당 게시물에 대해 사용자가 좋아요를 눌렀는지 여부를 반환합니다."
+    )
+    @GetMapping("/{articleId}/likes/status")
+    public ResponseEntity<ApiResponse<LikeStatusResponseDTO>> getLikeStatus(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        LikeStatusResponseDTO response = articleLikeQueryService.getLikeStatus(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
 
     @Operation(
             summary = "좋아요 등록",
-            description = "좋아요가 성공적으로 등록되었습니다."
+            description = "좋아요가 성공적으로 등록되었는지 확인합니다."
     )
     @PostMapping("/{articleId}/likes")
     public ResponseEntity<ApiResponse<LikeResponseDTO>> likeArticle(
@@ -43,7 +59,7 @@ public class ArticleLikeController {
 
     @Operation(
             summary = "좋아요 취소",
-            description = "좋아요가 성공적으로 취소되었습니다."
+            description = "좋아요가 성공적으로 취소되었는지 확인합니다."
     )
     @DeleteMapping("/{articleId}/likes")
     public ResponseEntity<ApiResponse<LikeResponseDTO>> unlikeArticle(

--- a/src/main/java/DNBN/spring/web/controller/ArticleSpamController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleSpamController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.*;
 @SecurityRequirement(name = "JWT TOKEN")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/articles")
+@RequestMapping("/api/articles")
 public class ArticleSpamController {
 
     private final ArticleSpamService articleSpamService;

--- a/src/main/java/DNBN/spring/web/controller/ArticleSpamController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleSpamController.java
@@ -1,0 +1,83 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
+import DNBN.spring.config.security.jwt.JwtTokenProvider;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.service.ArticleSpamService.ArticleSpamQueryService;
+import DNBN.spring.service.ArticleSpamService.ArticleSpamService;
+import DNBN.spring.web.dto.SpamResponseDTO;
+import DNBN.spring.web.dto.SpamStatusResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@SecurityRequirement(name = "JWT TOKEN")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/articles")
+public class ArticleSpamController {
+
+    private final ArticleSpamService articleSpamService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+    private final ArticleSpamQueryService articleSpamQueryService;
+
+    @Operation(
+            summary = "광고 의심 신고 여부 조회",
+            description = "해당 게시물에 대해 사용자가 광고 의심 신고를 눌렀는지 여부를 반환합니다."
+    )
+    @GetMapping("/{articleId}/spams/status")
+    public ResponseEntity<ApiResponse<SpamStatusResponseDTO>> getSpamStatus(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        SpamStatusResponseDTO response = articleSpamQueryService.getSpamStatus(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(
+            summary = "광고 의심 신고 등록",
+            description = "광고 의심 신고가 성공적으로 등록되었는지 확인합니다."
+    )
+    @PostMapping("/{articleId}/spams")
+    public ResponseEntity<ApiResponse<SpamResponseDTO>> spamArticle(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        SpamResponseDTO response = articleSpamService.spamArticle(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(
+            summary = "광고 의심 신고 취소",
+            description = "광고 의심 신고가 성공적으로 취소되었는지 확인합니다."
+    )
+    @DeleteMapping("/{articleId}/spams")
+    public ResponseEntity<ApiResponse<SpamResponseDTO>> unspamArticle(
+            @PathVariable Long articleId,
+            HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        Long memberId = extractMemberIdFromToken(token);
+        SpamResponseDTO response = articleSpamService.unspamArticle(articleId, memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+
+    private Long extractMemberIdFromToken(String token) {
+        if (token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        String socialId = jwtTokenProvider.getSubjectFromToken(token);
+        return memberRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND))
+                .getId();
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/CategoryController.java
+++ b/src/main/java/DNBN/spring/web/controller/CategoryController.java
@@ -1,0 +1,86 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
+import DNBN.spring.config.security.jwt.JwtTokenProvider;
+import DNBN.spring.domain.Member;
+import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.service.CategoryService.CategoryQueryService;
+import DNBN.spring.service.CategoryService.CategoryService;
+import DNBN.spring.web.dto.CategoryRequestDTO;
+import DNBN.spring.web.dto.CategoryResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@SecurityRequirement(name = "JWT TOKEN")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/categories")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+    private final CategoryQueryService categoryQueryService;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberRepository memberRepository;
+
+    @Operation(summary = "내 카테고리 목록 조회", description = "로그인한 사용자의 카테고리 목록을 반환합니다.")
+    @GetMapping("/my")
+    public ResponseEntity<ApiResponse<List<CategoryResponseDTO>>> getMyCategories(HttpServletRequest request) {
+        Long memberId = extractMemberIdFromToken(request);
+        List<CategoryResponseDTO> categories = categoryQueryService.getMyCategories(memberId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(categories));
+    }
+
+    @Operation(summary = "카테고리 등록", description = "새로운 카테고리를 추가합니다.")
+    @PostMapping
+    public ResponseEntity<ApiResponse<CategoryResponseDTO>> addCategory(
+            HttpServletRequest request,
+            @RequestBody @Valid CategoryRequestDTO dto) {
+        Long memberId = extractMemberIdFromToken(request);
+        CategoryResponseDTO response = categoryService.create(memberId, dto);
+        return ResponseEntity.status(HttpStatus.CREATED).body(ApiResponse.onSuccess(response));
+
+    }
+
+    @Operation(summary = "카테고리 수정", description = "카테고리 이름 또는 색상을 수정합니다.")
+    @PutMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<CategoryResponseDTO>> updateCategory(
+            HttpServletRequest request,
+            @PathVariable Long categoryId,
+            @RequestBody @Valid CategoryRequestDTO dto) {
+        Long memberId = extractMemberIdFromToken(request);
+        CategoryResponseDTO response = categoryService.update(memberId, categoryId, dto);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "카테고리 삭제", description = "해당 카테고리를 삭제합니다.")
+    @DeleteMapping("/{categoryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteCategory(
+            HttpServletRequest request,
+            @PathVariable Long categoryId) {
+        Long memberId = extractMemberIdFromToken(request);
+        categoryService.delete(memberId, categoryId);
+        return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    private Long extractMemberIdFromToken(HttpServletRequest request) {
+        String token = JwtTokenProvider.resolveToken(request);
+        if (token != null && token.startsWith("Bearer ")) {
+            token = token.substring(7);
+        }
+
+        String socialId = jwtTokenProvider.getSubjectFromToken(token);
+        Member member = memberRepository.findBySocialId(socialId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        return member.getId();
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/CategoryRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/CategoryRequestDTO.java
@@ -9,5 +9,8 @@ public record CategoryRequestDTO(
         String name,
 
         @NotBlank(message = "색상은 필수입니다.")
-        String color
+        String color,
+        Long placeId,
+        Long regionId
+
 ) { }

--- a/src/main/java/DNBN/spring/web/dto/CategoryRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/CategoryRequestDTO.java
@@ -1,0 +1,13 @@
+package DNBN.spring.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record CategoryRequestDTO(
+        @NotBlank(message = "카테고리 이름은 필수입니다.")
+        @Size(min = 1, max = 20, message = "카테고리 이름은 1자 이상 20자 이하여야 합니다.")
+        String name,
+
+        @NotBlank(message = "색상은 필수입니다.")
+        String color
+) { }

--- a/src/main/java/DNBN/spring/web/dto/CategoryResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/CategoryResponseDTO.java
@@ -1,0 +1,6 @@
+package DNBN.spring.web.dto;
+
+public record CategoryResponseDTO(Long categoryId, String name, String color) { }
+
+
+

--- a/src/main/java/DNBN/spring/web/dto/LikeResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/LikeResponseDTO.java
@@ -9,13 +9,11 @@ import lombok.Getter;
 public class LikeResponseDTO {
     private Long articleId;
     private long likesCount;
-    private long spamCount;
 
-    public static LikeResponseDTO of(Long articleId, long likesCount, long spamCount) {
+    public static LikeResponseDTO of(Long articleId, long likesCount) {
         return LikeResponseDTO.builder()
                 .articleId(articleId)
                 .likesCount(likesCount)
-                .spamCount(spamCount)
                 .build();
     }
 }

--- a/src/main/java/DNBN/spring/web/dto/LikeResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/LikeResponseDTO.java
@@ -1,0 +1,21 @@
+package DNBN.spring.web.dto;
+
+import DNBN.spring.domain.Article;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class LikeResponseDTO {
+    private Long articleId;
+    private long likesCount;
+    private long spamCount;
+
+    public static LikeResponseDTO of(Long articleId, long likesCount, long spamCount) {
+        return LikeResponseDTO.builder()
+                .articleId(articleId)
+                .likesCount(likesCount)
+                .spamCount(spamCount)
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/LikeStatusResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/LikeStatusResponseDTO.java
@@ -1,0 +1,10 @@
+package DNBN.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class LikeStatusResponseDTO {
+    private boolean liked;
+}

--- a/src/main/java/DNBN/spring/web/dto/LikeStatusResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/LikeStatusResponseDTO.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class LikeStatusResponseDTO {
-    private boolean liked;
+    private Long articleId;
+    private long likesCount;
 }

--- a/src/main/java/DNBN/spring/web/dto/SpamResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/SpamResponseDTO.java
@@ -8,13 +8,11 @@ import lombok.Getter;
 public class SpamResponseDTO {
     private Long articleId;
     private long spamsCount;
-    private long spamCount;
 
-    public static SpamResponseDTO of(Long articleId, long spamsCount, long spamCount) {
+    public static SpamResponseDTO of(Long articleId, long spamsCount) {
         return SpamResponseDTO.builder()
                 .articleId(articleId)
                 .spamsCount(spamsCount)
-                .spamCount(spamCount)
                 .build();
     }
 }

--- a/src/main/java/DNBN/spring/web/dto/SpamResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/SpamResponseDTO.java
@@ -1,0 +1,20 @@
+package DNBN.spring.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class SpamResponseDTO {
+    private Long articleId;
+    private long spamsCount;
+    private long spamCount;
+
+    public static SpamResponseDTO of(Long articleId, long spamsCount, long spamCount) {
+        return SpamResponseDTO.builder()
+                .articleId(articleId)
+                .spamsCount(spamsCount)
+                .spamCount(spamCount)
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/SpamStatusResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/SpamStatusResponseDTO.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class SpamStatusResponseDTO {
-    private boolean spamed;
+    private Long articleId;
+    private long spamsCount;
 }

--- a/src/main/java/DNBN/spring/web/dto/SpamStatusResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/SpamStatusResponseDTO.java
@@ -1,0 +1,10 @@
+package DNBN.spring.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class SpamStatusResponseDTO {
+    private boolean spamed;
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
>카테고리 CRUD 기능 구현 및 JWT 인증 기반 사용자 연동

## 🛠️ 작업 상세 내용
- [x] 카테고리 생성 API 구현 (`POST /api/categories`)
  - 이름 중복 검증
  - 사용자 정보와 연동하여 저장
- [x] 카테고리 목록 조회 API 구현 (`GET /api/categories/my`)
  - JWT 토큰 기반 사용자 인증 후 해당 사용자의 카테고리만 조회
- [x] 카테고리 수정 API 구현 (`PUT /api/categories/{categoryId}`)
  - 이름 및 색상 변경 가능
- [x] 카테고리 삭제 API 구현 (`DELETE /api/categories/{categoryId}`)
  - Soft delete 방식 적용 (`deletedAt` 처리)
- [x] `Color` enum 처리 및 문자열 매핑 기능 구현
- [x] `CategoryHandler`, `ErrorStatus` 커스텀 예외 처리 적용
- [x] `MemberRepository`, JWT 토큰 파싱 로직 활용해 사용자 식별
- [x] Swagger 문서화: 각 API에 대한 Operation 어노테이션 작성
- [x] DTO 설계 (`CategoryRequestDTO`, `CategoryResponseDTO`)
- [x] ApiResponse 포맷 통일 (`ApiResponse.onSuccess` 사용)

## 📸 스크린샷 (선택)
<img width="1223" height="1259" alt="image" src="https://github.com/user-attachments/assets/f9ed115b-fc48-493d-9863-275a5ee0189b" />
<img width="1220" height="949" alt="image" src="https://github.com/user-attachments/assets/e0d69059-8cfb-4341-8763-1a870f392209" />
<img width="1218" height="1124" alt="image" src="https://github.com/user-attachments/assets/92472318-677d-43cd-b1a9-67368aa53176" />
<img width="1219" height="922" alt="image" src="https://github.com/user-attachments/assets/f325fa01-65d3-4d82-bceb-cca39d918014" />

## 💬 기타(공유사항 to 리뷰어)
- JWT 토큰은 `Bearer ` prefix 제거 후 파싱  
- `CategoryRepository.findByIdAndMemberAndDeletedAtIsNull` 메서드 오류 수정 (id → categoryId)  
- `Place`, `Region` 연동 구현 완료
- TEST 하는 방법!!
- 1. kako, naver, goole 중에 하나로 로그인해서 token 받기 (naver 추천 memberid 보기 쉬움)
- 2. 받은 token authorize에 넣기
- 3. 내 memberid 확인 후 datagrip에서 article, category에 들어있는 값들의 memberid를 내 id로 바꾸고 업로드 하기
- 4. swagger에서 articleid 3으로 넣고 test 하기
<img width="1194" height="881" alt="image" src="https://github.com/user-attachments/assets/382a0ae0-2ad1-4cfa-8df2-7b013dddcdd8" />
