### PR TITLE
✨ [Fix] 토큰 관련 이슈 해결

### DIFF
--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -89,7 +89,9 @@ public class SecurityConfig {
                 .exceptionHandling(exception -> exception
                         .authenticationEntryPoint(customAuthenticationEntryPoint)
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+//                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);
+
 
         return http.build();
     }
@@ -99,4 +101,9 @@ public class SecurityConfig {
 //    public PasswordEncoder passwordEncoder() { // 비밀번호를 암호화하여 저장하기 위해
 //        return new BCryptPasswordEncoder();
 //    }
+
+    @Bean
+    public JwtAuthenticationFilter jwtAuthenticationFilter() {
+        return new JwtAuthenticationFilter(jwtTokenProvider);
+    }
 }

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -71,7 +71,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         (requests) -> requests
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                .requestMatchers("/", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/", "/auth/reissue", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 //                                .requestMatchers("/admin/**").hasRole("ADMIN") // pm이 ADMIN역할 기능 필요 X
                                 .anyRequest().authenticated()
                 )

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -6,6 +6,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
@@ -13,10 +14,21 @@ import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
 
+@Slf4j
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter { // 필터 역할: 클라이언트가 서버에게 전달되기 전에 인증 과정
 
     private final JwtTokenProvider jwtTokenProvider;
+
+//    private static final Set<String> NO_FILTER_URIS = Set.of("/auth/reissue", ""); // /auth/reissue 외에도 필요하면
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        log.info("🔥 [JWT 필터 제외 검사]: {}", request.getRequestURI());
+        return request.getRequestURI().equals("/auth/reissue");
+//        return NO_FILTER_URIS.contains(request.getRequestURI()); // /auth/reissue 외에도 필요하면
+//        return super.shouldNotFilter(request);
+    }
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, // HttpServletRequest로 받아온 요청 객체에서 순수한 토큰을 추출

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,9 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // 필터 �
 
         String token = resolveToken(request);
 
-        if(StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) { // 순수한 토큰 검증 과정을 통과하면,
+        if(StringUtils.hasText(token) &&
+                jwtTokenProvider.validateToken(token) &&
+                jwtTokenProvider.isAccessToken(token)) { // 순수한 토큰 검증 과정을 통과하면,
             Authentication authentication = jwtTokenProvider.getAuthentication(token); // 인증 객체를 만들고,
             SecurityContextHolder.getContext().setAuthentication(authentication); // 인증을 등록
         }

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -72,6 +72,20 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
         }
     }
 
+    public boolean isAccessToken(String token) { // JwtAuthenticationFilter에서 사용
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            return "access".equals(claims.get("tokenType", String.class));
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
     public boolean isRefreshToken(String token) { // 토큰 재발급 API에서 사용
         try {
             Claims claims = Jwts.parserBuilder()

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -41,6 +41,7 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
         return Jwts.builder()
                 .setSubject(socialId)
                 .claim("role", authentication.getAuthorities().iterator().next().getAuthority())
+                .claim("tokenType", "access")
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getAccess()))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)
@@ -51,6 +52,7 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
         return Jwts.builder()
                 .setSubject(socialId)
 //                .claim("role", "ROLE_USER") // refreshToken은 단순히 "사용자 식별 정보"만 갖고 있는 재발급 전용 토큰이고, 실제 인증이나 권한 처리를 하지 않기 때문에 굳이 .claim("role", ...)를 포함할 필요가 없다
+                .claim("tokenType", "refresh")
                 .setIssuedAt(new Date())
                 .setExpiration(new Date(System.currentTimeMillis() + jwtProperties.getExpiration().getRefresh()))
                 .signWith(getSigningKey(), SignatureAlgorithm.HS256)

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -59,13 +59,31 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
                 .compact();
     }
 
-    public boolean validateToken(String token) { // 해당 JWT 토큰이 유효한지 검증
+    public boolean validateToken(String token) { // 해당 JWT 토큰이 유효한지(서명과 시간) 검증
         // 파싱이 된다면 유효한 토큰이고, 토큰이 만료되었거나 (앞서 저희가 걸었던 4시간 제한을 넘어갔다거나) 혹은 위조, 형식 오류가 생기면 예외가 발생하여 false를 반환
         try {
             Jwts.parserBuilder()
                     .setSigningKey(getSigningKey())
                     .build()
                     .parseClaimsJws(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            return false;
+        }
+    }
+
+    public boolean isRefreshToken(String token) { // 토큰 재발급 API에서 사용
+        try {
+            Claims claims = Jwts.parserBuilder()
+                    .setSigningKey(getSigningKey())
+                    .build()
+                    .parseClaimsJws(token)
+                    .getBody();
+
+            String tokenType = claims.get("tokenType", String.class);
+            if (!"refresh".equals(tokenType)) { // access인지 refresh인지 체크
+                return false;  // AccessToken이면 false
+            }
             return true;
         } catch (JwtException | IllegalArgumentException e) {
             return false;

--- a/src/main/java/DNBN/spring/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/AuthService/AuthCommandServiceImpl.java
@@ -21,8 +21,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     @Override
     public AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken) {
-        // 1. RefreshToken 유효성 검사
-        if (!jwtTokenProvider.validateToken(refreshToken)) {
+        // 1. RefreshToken 유효성 검사 (서명 및 토큰 타입까지 확인)
+        if (!jwtTokenProvider.isRefreshToken(refreshToken)) {
             throw new MemberHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN);
         }
 

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -1,6 +1,8 @@
 package DNBN.spring.web.controller;
 
 import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.MemberDetails;
 import DNBN.spring.service.AuthService.AuthCommandService;
@@ -11,6 +13,7 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -22,6 +25,7 @@ public class AuthRestController {
 
     private final MemberCommandService memberCommandService;
     private final AuthCommandService authCommandService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/logout")
     @Operation(summary = "회원 로그아웃 API - JWT 인증 필요",
@@ -39,6 +43,10 @@ public class AuthRestController {
     )
     public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request) {
         String refreshToken = JwtTokenProvider.resolveToken(request); // Authorization 헤더에서 Bearer 토큰을 추출
+        if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) { // refreshToken == null은 !StringUtils.hasText(refreshToken)로 체크 가능
+            throw new MemberHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN); // TOKEN4002
+        }
+
         AuthResponseDTO.ReissueTokenResponseDTO response = authCommandService.reissue(refreshToken);
         return ApiResponse.onSuccess(response);
     }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 토큰 관련 이슈 발견함
스웨거에서 Authorize에 아무것도 안 넣고 토큰 재발급하면 4001이 보임 --> 4002가 보여야 함
스웨거에서 Authorize에 access token 넣고 토큰 재발급하면 4001과 4002가 보임 --> 4002가 보여야 함
스웨거에서 Authorize에 refresh token 넣고 토큰 재발급하면 4001가 보임 --> 4002가 보여야 하며, 정상 동작해서 성공해야 함

## 🛠️ 작업 상세 내용
- [x] access와 refresh토큰 타입 명시
- [x] 토큰 확인 함수 추가
- [x] 위의 3가지 문제 해결함

## 📸 스크린샷 (선택)
아래 6가지 확인함
스웨거에서 Authorize에 아무것도 안 넣고 회원 정보 조회
<img width="1167" height="849" alt="image" src="https://github.com/user-attachments/assets/d8204edc-193b-47cc-98fe-ab174791e0ac" />
스웨거에서 Authorize에 아무것도 안 넣고 토큰 재발급
<img width="1160" height="833" alt="image" src="https://github.com/user-attachments/assets/94331c27-dd66-4df1-b6df-95fa93c0ace3" />

스웨거에서 Authorize에 access token 넣고 회원 정보 조회
<img width="1160" height="859" alt="image" src="https://github.com/user-attachments/assets/ae5ed311-47e9-46bd-8c1d-c242bfe0ed1a" />
스웨거에서 Authorize에 access token 넣고 토큰 재발급
<img width="1163" height="864" alt="image" src="https://github.com/user-attachments/assets/7940375e-76b5-4b7f-8460-b78dd9571c09" />

스웨거에서 Authorize에 refresh token 넣고 회원 정보 조회
<img width="1158" height="865" alt="image" src="https://github.com/user-attachments/assets/36236887-7888-4299-8796-4e4635aad3ab" />
스웨거에서 Authorize에 refresh token 넣고 토큰 재발급
<img width="1164" height="868" alt="image" src="https://github.com/user-attachments/assets/260fbb01-aed8-4540-96f0-b4ddfc077fea" />

## 💬 기타(공유사항 to 리뷰어)
브랜치 삭제하지 말아주세요

git fetch origin 하고
feat/genie/37로 체크아웃 하고
인텔리제이 run하고
(아래 셋 중에 하나로 소셜 로그인해서 토큰 복붙해놓기!
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google
)

위의 캡쳐된 6가지 해보시면 됩니다.
응답 똑같이 나오면 정상(4001, 4002, 성공 유심히 봐주세요)
다르게 나오면 리뷰 달고 저한테 알려주세요~