### PR TITLE
✨ [Feat] 관심 동네 변경

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -45,7 +45,6 @@ public enum ErrorStatus implements BaseErrorCode {
     // 장소 저장 에러
     CATEGORY_ALREADY_SAVED_FOR_PLACE(HttpStatus.CONFLICT, "SAVE_PLACE4001", "이미 해당 장소가 이 카테고리에 저장되어 있습니다."),
 
-
     //like
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시물을 찾을 수 없습니다."),
     ALREADY_LIKED(HttpStatus.CONFLICT, "LIKE4001", "이미 좋아요를 누르셨습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -44,6 +44,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 장소 저장 에러
     CATEGORY_ALREADY_SAVED_FOR_PLACE(HttpStatus.CONFLICT, "SAVE_PLACE4001", "이미 해당 장소가 이 카테고리에 저장되어 있습니다."),
+    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "해당 장소를 찾을 수 없습니다."),
 
     //like
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시물을 찾을 수 없습니다."),
@@ -58,9 +59,8 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_INVALID_NAME(HttpStatus.BAD_REQUEST, "CATEGORY_400_INVALID_NAME", "카테고리 이름이 유효하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_404_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
     CATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, "CATEGORY_409_DUPLICATE_NAME", "이미 존재하는 카테고리 이름입니다."),
-    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다."),
+    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다.");
 
-    PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "해당 장소를 찾을 수 없습니다.");
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/DNBN/spring/repository/LikeRegionRepository/LikeRegionRepository.java
+++ b/src/main/java/DNBN/spring/repository/LikeRegionRepository/LikeRegionRepository.java
@@ -10,4 +10,5 @@ import java.util.List;
 public interface LikeRegionRepository extends JpaRepository<LikeRegion, Long> {
     List<LikeRegion> findAllByMember(Member member);
     List<LikeRegion> findAllByRegion(Region region);
+    void deleteByMember(Member member);
 }

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
@@ -2,11 +2,15 @@ package DNBN.spring.service.MemberService;
 
 import DNBN.spring.domain.Member;
 import DNBN.spring.web.dto.MemberRequestDTO;
+import DNBN.spring.web.dto.MemberResponseDTO;
 import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface MemberCommandService {
     Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage);
     void logout(Long memberId);
     void deleteMember(Long memberId);
     void changeMemberNickname(Long memberId, String newNickname);
+    MemberResponseDTO.ChosenRegionsDTO updateRegions(Long memberId, List<Long> regionIds);
 }

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -87,4 +87,19 @@ public class MemberRestController {
         return ApiResponse.onSuccess(null);
 //        return ApiResponse.onSuccess(memberCommandervice.changeMemberNickname(request));
     }
+
+    @PatchMapping("/regions")
+    @Operation(
+            summary = "관심 동네 변경 API - JWT 인증 필요",
+            description = "JWT 인증된 멤버가 자신의 관심 동네를 수정하는 API입니다.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ApiResponse<MemberResponseDTO.ChosenRegionsDTO> updateRegions(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestBody @Valid MemberRequestDTO.RegionUpdateDTO request) {
+
+        Long memberId = memberDetails.getMember().getId();
+        MemberResponseDTO.ChosenRegionsDTO response = memberCommandService.updateRegions(memberId, request.getRegionIds());
+        return ApiResponse.onSuccess(response);
+    }
 }

--- a/src/main/java/DNBN/spring/web/dto/MemberRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/MemberRequestDTO.java
@@ -3,6 +3,8 @@ package DNBN.spring.web.dto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -27,5 +29,14 @@ public class MemberRequestDTO {
     public static class NicknameUpdateDTO {
         @NotBlank(message = "닉네임은 필수입니다.")
         String nickname;
+    }
+
+    @Getter
+    @Setter
+    public static class RegionUpdateDTO {
+
+        @NotNull(message = "관심 동네 ID 목록은 필수입니다.")
+        @Size(min = 1, max = 3, message = "관심 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다.")
+        List<Long> regionIds;
     }
 }

--- a/src/main/java/DNBN/spring/web/dto/MemberResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/MemberResponseDTO.java
@@ -29,4 +29,17 @@ public class MemberResponseDTO {
         String profileImage;
         List<RegionResponseDTO.RegionPreviewnDTO> likeRegions;
     }
+
+    @Getter
+    @Builder
+    public static class ChosenRegionsDTO {
+        private List<RegionInfo> chosenRegions;
+
+        @Getter
+        @Builder
+        public static class RegionInfo {
+            Long regionId;
+            String district;
+        }
+    }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> PATCH /api/member/regions API 구현
> 프론트에서 regionIds 리스트를 받아 기존 관심 동네를 초기화 후 재저장

## 🛠️ 작업 상세 내용
- [x] MemberRestController에서 토큰 기반으로 사용자 식별
- [x] MemberCommandService에서 관심 동네 변경 비즈니스 로직 처리
- [x] 아래 조건에 대해 예외 처리 및 커스텀 핸들러 작성
       - regionIds가 1개 미만 또는 3개 초과인 경우 → MemberHandler 사용, INVALID_REGION_COUNT 반환
       - 전달받은 지역 ID 중 존재하지 않는 ID가 포함된 경우 → RegionHandler 사용, REGION_NOT_FOUND 반환
- [x] LikeRegionRepository의 deleteByMember() 호출로 기존 관심 동네 초기화
- [x] LikeRegion.of()를 통해 새롭게 관심 동네 매핑 후 일괄 저장
- [x] Swagger 문서에서 @SecurityRequirement(name = "JWT TOKEN") 설정 적용

## 📸 스크린샷 (선택)
<img width="1220" height="637" alt="스크린샷 2025-07-20 오전 12 45 59" src="https://github.com/user-attachments/assets/1637b38a-4254-4dc9-ac81-4bba8d9e3c3d" />

<img width="1200" height="254" alt="스크린샷 2025-07-20 오전 12 46 32" src="https://github.com/user-attachments/assets/bcc10fe0-e64b-4023-b1eb-260e89a928ba" />

<img width="1228" height="301" alt="스크린샷 2025-07-20 오전 12 47 01" src="https://github.com/user-attachments/assets/55499368-07e7-4db8-9436-94cedf94e1ce" />

## 💬 기타(공유사항 to 리뷰어)
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google

1. 관심 동네 0 입력 시 "해당 지역이 존재하지 않습니다." 에러 발생
2. 관심 동네 id값 아무것도 입력하지 않을 시 "관심 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다." 에러 발생
3. id값 3개 이상 입력 시 "관심 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다." 에러 발생
