### PR TITLE
🔨  [Fix] 이미지 업로드 용량 초과 시 Swagger 'failed to fetch' 오류 해결

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/ExceptionAdvice.java
@@ -68,7 +68,11 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleMaxUploadSizeExceededException(
             MaxUploadSizeExceededException e, HttpHeaders headers, HttpStatusCode status, WebRequest request) {
-//        log.error("[handleMaxUploadSizeExceededException] 진입: {}", e.getMessage(), e);
+        String requestUri = "";
+        if (request instanceof ServletWebRequest servletWebRequest) {
+            requestUri = servletWebRequest.getRequest().getRequestURI();
+        }
+        log.error("\uD83D\uDCBE [이미지 업로드 용량 초과]: {} | 요청 URI: {}", e.getMessage(), requestUri);
         ResponseEntity<Object> response = handleExceptionInternalFalse(
                 e,
                 ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE,
@@ -77,7 +81,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
                 request,
                 e.getMessage()
         );
-        log.error("[handleMaxUploadSizeExceededException] 응답: status={}, body={}", response.getStatusCode(), response.getBody());
+        log.error("\uD83D\uDCBE [이미지 업로드 용량 초과 응답]: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,9 @@ spring:
     multipart:
       maxFileSize: 10MB # 파일 하나의 최대 크기
       maxRequestSize: 100MB  # 한 번에 최대 업로드 가능 용량
+server:
+  tomcat:
+    max-swallow-size: 200MB
 jwt:
   token:
     secretKey: ${JWT_SECRETKEY}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -70,6 +70,14 @@ spring:
     multipart:
       maxFileSize: 10MB # 파일 하나의 최대 크기
       maxRequestSize: 100MB  # 한 번에 최대 업로드 가능 용량
+      # resolve-lazily 옵션 설명:
+      # false (기본값): 파일 파싱이 컨트롤러 진입 전에 이뤄짐
+      #   - 파일 크기 초과 등 예외가 Spring의 ExceptionHandler(@ExceptionHandler)에서 처리됨
+      #   - 대부분의 서비스에서 사용하는 일반적인 방식
+      # true: 파일 파싱을 컨트롤러 파라미터 바인딩 시점으로 미룸
+      #   - 인증/권한 체크 전에 파일 파싱을 막고 싶을 때 사용(보안 목적)
+      #   - 이 경우 파일 크기 초과 등 예외가 ExceptionHandler까지 도달하지 않고, 더 앞단(서블릿 컨테이너 등)에서 처리됨
+      resolve-lazily: false
 server:
   tomcat:
     max-swallow-size: 200MB


### PR DESCRIPTION
## #️⃣ 기능 설명
> `max-swallow-size`를 설정해 이미지 업로드 용량 초과(MaxUploadSizeExceededException) 발생 시에도 Spring이 아닌 에러 핸들러가 예외를 처리하도록 조정 

## 🛠️ 작업 상세 내용
- [x] `max-swallow-size` 설정
- [x] 예외 로그 이모티콘 및 형식 통일
- [x] 파일 파싱 시점을 설정할 수 있는 multipart 설정(resolve-lazily) 옵션 추가

## 📸 스크린샷 (선택)
<img width="1038" height="60" alt="image" src="https://github.com/user-attachments/assets/fbfaa3de-b13d-42e3-a5ff-25f0a11295e2" />
<img width="1164" height="390" alt="image" src="https://github.com/user-attachments/assets/8f4f9ee9-2fdf-4d59-af31-47eb5bf79261" />

## 💬 기타(공유사항 to 리뷰어)
- `max-swallow-size`는 정상적인 사용자가 올릴 수 있는 이미지 용량까지만 예외로 처리할 수 있도록 200MB로 설정하였습니다.
- Dos 공격 등 비정상적인 대용량 파일에는 같은 문제가 발생할 수 있습니다.