### PR TITLE
✨ [Feat] 프로필 이미지 변경

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -21,6 +21,8 @@ public enum ErrorStatus implements BaseErrorCode {
     ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 사용자입니다. 온보딩을 마치지 않았습니다."),
     INVALID_REGION_COUNT(HttpStatus.BAD_REQUEST, "MEMBER4004", "좋아하는 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다."),
     SOCIALID_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4005", "socialId가 없습니다."),
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4006", "이미지 형식의 파일만 업로드할 수 있습니다."),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4007", "이미지 파일은 10MB 이하로 업로드해주세요."),
     
     // article
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -21,7 +21,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 사용자입니다. 온보딩을 마치지 않았습니다."),
     INVALID_REGION_COUNT(HttpStatus.BAD_REQUEST, "MEMBER4004", "좋아하는 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다."),
     SOCIALID_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4005", "socialId가 없습니다."),
-    
+    INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4006", "이미지 형식의 파일만 업로드할 수 있습니다."),
+    IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4007", "이미지 파일은 10MB 이하로 업로드해주세요."),
+
     // 예시,,,
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
 

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -19,9 +19,11 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_INFO_RETRIEVED(HttpStatus.OK, "MEMBER2004", "유저 정보를 성공적으로 조회했습니다."),
     MEMBER_LOGOUT_SUCCESS(HttpStatus.OK, "MEMBER2005", "로그아웃이 완료되었습니다."),
     MEMBER_DELETE_SUCCESS(HttpStatus.OK, "MEMBER2006", "회원 탈퇴가 완료되었습니다."),
+    MEMBER_PROFILE_IMAGE_UPDATED(HttpStatus.OK, "MEMBER2007", "프로필 이미지가 성공적으로 변경되었습니다."),
 
     // 장소 저장 관련 응답
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다.");
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/DNBN/spring/apiPayload/exception/ExceptionAdvice.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/ExceptionAdvice.java
@@ -72,16 +72,29 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         if (request instanceof ServletWebRequest servletWebRequest) {
             requestUri = servletWebRequest.getRequest().getRequestURI();
         }
-        log.error("\uD83D\uDCBE [이미지 업로드 용량 초과]: {} | 요청 URI: {}", e.getMessage(), requestUri);
+
+        log.error("📦 [이미지 업로드 용량 초과]: {} | 요청 URI: {}", e.getMessage(), requestUri);
+
+        ErrorStatus errorStatus;
+
+        if (requestUri.contains("/member/profile-image")) {
+            errorStatus = ErrorStatus.IMAGE_FILE_TOO_LARGE; // 멤버 프로필 이미지 업로드 실패 시
+        } else if (requestUri.contains("/article") || requestUri.contains("/articles")) {
+            errorStatus = ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE; // 게시글 이미지 업로드 실패 시
+        } else {
+            errorStatus = ErrorStatus._BAD_REQUEST; // 그 외 요청
+        }
+
         ResponseEntity<Object> response = handleExceptionInternalFalse(
                 e,
-                ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE,
+                errorStatus,
                 HttpHeaders.EMPTY,
-                ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE.getHttpStatus(),
+                errorStatus.getHttpStatus(),
                 request,
                 e.getMessage()
         );
-        log.error("\uD83D\uDCBE [이미지 업로드 용량 초과 응답]: status={}, body={}", response.getStatusCode(), response.getBody());
+
+        log.error("📦 [이미지 업로드 용량 초과 응답]: status={}, body={}", response.getStatusCode(), response.getBody());
         return response;
     }
 

--- a/src/main/java/DNBN/spring/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/DNBN/spring/aws/s3/AmazonS3Manager.java
@@ -41,6 +41,17 @@ public class AmazonS3Manager{
         return amazonConfig.getMemberPath() + '/' + uuid.getUuid(); // 멤버 프로필 사진
     }
 
+    public String extractS3KeyFromUrl(String imageUrl) {
+        String bucketUrlPrefix = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
+
+        if (imageUrl != null && imageUrl.startsWith(bucketUrlPrefix)) {
+            return imageUrl.substring(bucketUrlPrefix.length());
+        } else {
+            throw new IllegalArgumentException("S3 URL에서 key를 추출할 수 없습니다: " + imageUrl);
+        }
+    }
+
+
     public void deleteFile(String keyName) {
         amazonS3.deleteObject(amazonConfig.getBucket(), keyName);
     }

--- a/src/main/java/DNBN/spring/aws/s3/AmazonS3Manager.java
+++ b/src/main/java/DNBN/spring/aws/s3/AmazonS3Manager.java
@@ -45,6 +45,16 @@ public class AmazonS3Manager{
         return amazonConfig.getArticlePhotoPath() + '/' + uuid;
     }
 
+    public String extractS3KeyFromUrl(String imageUrl) {
+        String bucketUrlPrefix = "https://" + amazonConfig.getBucket() + ".s3." + amazonConfig.getRegion() + ".amazonaws.com/";
+
+        if (imageUrl != null && imageUrl.startsWith(bucketUrlPrefix)) {
+            return imageUrl.substring(bucketUrlPrefix.length());
+        } else {
+            throw new IllegalArgumentException("S3 URL에서 key를 추출할 수 없습니다: " + imageUrl);
+        }
+    }
+
     public void deleteFile(String keyName) {
         amazonS3.deleteObject(amazonConfig.getBucket(), keyName);
     }

--- a/src/main/java/DNBN/spring/domain/ProfileImage.java
+++ b/src/main/java/DNBN/spring/domain/ProfileImage.java
@@ -19,4 +19,8 @@ public class ProfileImage extends BaseEntity {
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    public void updateImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
+    }
 }

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
@@ -13,4 +13,5 @@ public interface MemberCommandService {
     void deleteMember(Long memberId);
     void changeMemberNickname(Long memberId, String newNickname);
     MemberResponseDTO.ChosenRegionsDTO updateRegions(Long memberId, List<Long> regionIds);
+    MemberResponseDTO.ProfileImageUpdateResultDTO updateProfileImage(Long memberId, MultipartFile profileImage);
 }

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -102,4 +102,23 @@ public class MemberRestController {
         MemberResponseDTO.ChosenRegionsDTO response = memberCommandService.updateRegions(memberId, request.getRegionIds());
         return ApiResponse.onSuccess(response);
     }
+
+    @PatchMapping(
+            value = "/profile-image",
+            consumes = MediaType.MULTIPART_FORM_DATA_VALUE
+    )
+    @Operation(
+            summary = "프로필 이미지 변경 API - JWT 인증 필요",
+            description = "JWT 인증된 사용자가 프로필 이미지를 변경합니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ApiResponse<MemberResponseDTO.ProfileImageUpdateResultDTO> updateProfileImage(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestPart("profileImage") MultipartFile profileImage
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        MemberResponseDTO.ProfileImageUpdateResultDTO result = memberCommandService.updateProfileImage(memberId, profileImage);
+        return ApiResponse.onSuccess(result);
+    }
+
 }

--- a/src/main/java/DNBN/spring/web/dto/MemberResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/MemberResponseDTO.java
@@ -1,9 +1,6 @@
 package DNBN.spring.web.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
@@ -42,4 +39,14 @@ public class MemberResponseDTO {
             String district;
         }
     }
+
+    @Getter
+    @Setter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfileImageUpdateResultDTO {
+        private String profileImageUrl;
+    }
+
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
- 프로필 이미지 변경 api PATCH /member/profile-image 구현

## 🛠️ 작업 상세 내용
- [x] MultipartFile을 통한 이미지 업로드 처리
- [x] S3에 기존 이미지 삭제 및 새 이미지 업로드
- [x] UUID를 통한 S3 key 관리
- [x] 용량 제한(10MB), 형식 제한(image/*) 등 유효성 검증 추가
- [x] 최대 업로드 용량 초과 시 request URI 기반 에러 코드 분기 처리 (`IMAGE4007` 등) -> ExceptionAdvice 클래스 수정

## 📸 스크린샷 (선택)
<img width="1218" height="285" alt="스크린샷 2025-07-21 오전 6 33 51" src="https://github.com/user-attachments/assets/e0573417-f473-4988-a8b9-963a099024eb" />

<img width="1233" height="264" alt="스크린샷 2025-07-21 오전 6 32 11" src="https://github.com/user-attachments/assets/c8e244d3-90fe-4493-9155-84dfda23c821" />

<img width="1228" height="278" alt="스크린샷 2025-07-21 오전 6 32 23" src="https://github.com/user-attachments/assets/291938c2-dbe2-4d12-b8e0-9a9f430059f4" />


## 💬 기타(공유사항 to 리뷰어)

http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google

1. 파일 형식 에러
2. 이미지 파일 용량 제한 에러 (10MB)
