### PR TITLE
✨ [Feat] 게시물 삭제 API 구현

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -28,6 +28,8 @@ public enum ErrorStatus implements BaseErrorCode {
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
     ARTICLE_TITLE_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "ARTICLE4002", "제목은 2~100자여야 합니다."),
     ARTICLE_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "ARTICLE4003", "내용은 10~5000자여야 합니다."),
+    ARTICLE_FORBIDDEN(HttpStatus.FORBIDDEN, "ARTICLE4004", "해당 게시글에 대한 권한이 없습니다."),
+    ARTICLE_ALREADY_DELETED(HttpStatus.CONFLICT, "ARTICLE4005", "이미 삭제된 게시글입니다."),
 
     // articlePhoto & S3
     ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "ARTICLEPHOTO4002", "대표 이미지는 필수입니다."),

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -56,4 +56,8 @@ public class Article extends BaseEntity {
   @Column(nullable = false)
   private LocalDate date;
 
+  public void delete() {
+        this.deletedAt = java.time.LocalDateTime.now();
+    }
+
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandService.java
@@ -10,6 +10,8 @@ import org.springframework.web.multipart.MultipartFile;
 public interface ArticleCommandService {
     ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles);
 
+    void deleteArticle(Long memberId, Long articleId);
+
     @AllArgsConstructor
     class ArticleWithPhotos {
         public final Article article;

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -175,4 +175,18 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         }
         return new ArticleWithPhotos(article, photos);
     }
+
+    @Override
+    @Transactional
+    public void deleteArticle(Long memberId, Long articleId) {
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
+        if (!article.getMember().getId().equals(memberId)) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
+        }
+        if (article.getDeletedAt() != null) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
+        }
+        article.delete(); // dirty checking
+    }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -32,6 +32,7 @@ import org.springframework.web.multipart.MultipartFile;
 @Slf4j
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class ArticleCommandServiceImpl implements ArticleCommandService {
     private static final int MAX_IMAGE_COUNT = 10;
     private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
@@ -49,7 +50,6 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     private final AmazonS3Manager s3Manager;
 
     @Override
-    @Transactional
     public ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -177,7 +177,6 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     }
 
     @Override
-    @Transactional
     public void deleteArticle(Long memberId, Long articleId) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -12,6 +12,8 @@ import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestPart;
@@ -41,5 +43,20 @@ public class ArticleController {
         ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, dto, mainImage, imageFiles);
         ArticleResponseDTO response = ArticleConverter.toArticleResponseDTO(result.article, result.photos);
         return ApiResponse.onSuccess(response);
+    }
+
+    @DeleteMapping("/{articleId}")
+    @Operation(
+        summary = "게시물 삭제",
+        description = "게시물을 삭제합니다. JWT 인증 필요.",
+        security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ApiResponse<Void> deleteArticle(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long articleId
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        articleCommandService.deleteArticle(memberId, articleId);
+        return ApiResponse.onSuccess(null);
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 게시물 삭제 API

## 🛠️ 작업 상세 내용
- [x] 게시글 삭제 기능 구현
- [x] 검증 및 예외 처리
  - [x] 게시글 존재 여부
  - [x] 작성자 일치 여부
  - [x] 이미 삭제한 게시글
- [x] Swagger 명세 작성

## 📸 스크린샷 (선택)
**게시글 존재 검증**
<img width="1190" height="358" alt="image" src="https://github.com/user-attachments/assets/7a3b61d1-e4bd-45f5-bd25-118b3e1b8095" />
**작성자 일치 검증**
<img width="1193" height="360" alt="image" src="https://github.com/user-attachments/assets/0c75dd27-6af2-40d3-a0ee-51f6120fe5a5" />
**이미 삭제한 게시글 여부 검증**
<img width="1194" height="363" alt="image" src="https://github.com/user-attachments/assets/e165d554-4d94-42f1-baf5-604786fe61d9" />

## 💬 기타(공유사항 to 리뷰어)
### 테스트에 필요한 링크
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google