### PR TITLE
✨ [Feat] 게시물 생성 (미등록 장소) API 구현

### DIFF
--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandService.java
@@ -3,12 +3,14 @@ package DNBN.spring.service.ArticleService;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.ArticlePhoto;
 import DNBN.spring.web.dto.ArticleRequestDTO;
+import DNBN.spring.web.dto.ArticleWithLocationRequestDTO;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import org.springframework.web.multipart.MultipartFile;
 
 public interface ArticleCommandService {
     ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles);
+    ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles);
 
     void deleteArticle(Long memberId, Long articleId);
 

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -6,6 +6,7 @@ import DNBN.spring.domain.MemberDetails;
 import DNBN.spring.service.ArticleService.ArticleCommandService;
 import DNBN.spring.web.dto.ArticleRequestDTO;
 import DNBN.spring.web.dto.ArticleResponseDTO;
+import DNBN.spring.web.dto.ArticleWithLocationRequestDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.validation.Valid;
@@ -36,6 +37,24 @@ public class ArticleController {
     public ApiResponse<ArticleResponseDTO> createArticle(
             @AuthenticationPrincipal MemberDetails memberDetails,
             @RequestPart("request") @Valid ArticleRequestDTO dto,
+            @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
+            @RequestPart(value = "imageFiles", required = false) List<MultipartFile> imageFiles
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, dto, mainImage, imageFiles);
+        ArticleResponseDTO response = ArticleConverter.toArticleResponseDTO(result.article, result.photos);
+        return ApiResponse.onSuccess(response);
+    }
+
+    @PostMapping(value = "/with-location", consumes = {"multipart/form-data"})
+    @Operation(
+            summary = "게시물 생성 (미등록 장소)",
+            description = "핀(장소)이 등록되지 않은 경우, 위도/경도로 장소를 지정해 게시물을 등록합니다. JWT 인증 필요.",
+            security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ApiResponse<ArticleResponseDTO> createArticleWithLocation(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestPart("request") @Valid ArticleWithLocationRequestDTO dto,
             @RequestPart(value = "mainImage", required = false) MultipartFile mainImage,
             @RequestPart(value = "imageFiles", required = false) List<MultipartFile> imageFiles
     ) {

--- a/src/main/java/DNBN/spring/web/dto/ArticleWithLocationRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/ArticleWithLocationRequestDTO.java
@@ -3,14 +3,16 @@ package DNBN.spring.web.dto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
+import java.util.List;
 
 /**
- * 핀이 이미 등록되어 있는 경우의 게시글 생성을 위한 요청 DTO
+ * 핀이 등록되지 않은(신규 장소)의 게시글 생성을 위한 요청 DTO
  */
-public record ArticleRequestDTO(
+public record ArticleWithLocationRequestDTO(
     @NotNull(message = "카테고리 ID는 필수입니다.") Long categoryId,
     @NotNull(message = "장소 ID는 필수입니다.") Long placeId,
-    @NotNull(message = "지역 ID는 필수입니다.") Long regionId,
+    @NotNull(message = "위도는 필수입니다.") Double latitude,
+    @NotNull(message = "경도는 필수입니다.") Double longitude,
     @NotBlank(message = "제목은 필수입니다.") String title,
     @NotNull(message = "날짜는 필수입니다.") LocalDate date,
     @NotBlank(message = "내용은 필수입니다.") String content


### PR DESCRIPTION
## #️⃣ 기능 설명
> `regionId` 대신 위도와 경도를 받아, `Region` 생성 후 게시물을 생성하는 API

## 📸 스크린샷 (선택)
**요청**
<img width="1168" height="875" alt="image" src="https://github.com/user-attachments/assets/43d07263-8750-4e85-8420-184fed0debdd" />
**응답**
<img width="1189" height="736" alt="image" src="https://github.com/user-attachments/assets/71260c14-b77c-408b-bfb1-ff04c41431f3" />
**추가된 `Region` 데이터 (위도 1, 경도 1)**
<img width="1616" height="122" alt="image" src="https://github.com/user-attachments/assets/e8e2f824-2729-4732-a243-a6f92e8b05af" />


## 💬 기타(공유사항 to 리뷰어)
- 기존의 게시물 생성 API와 같은 검증 로직을 사용하고 있습니다. (`Region` 검증 제외)
- `createArticle` 메서드를 오버로딩하였습니다. 두 함수 모두 리팩토링이 필요한 상황입니다.
- 기존 API와 검증 로직이 완전히 동일하여 테스트를 생략하였습니다.
- 지역 생성 API 구현 후 관련 로직을 다시 구현하고, 테스트도 그때 추가할 예정입니다.