### PR TITLE
✨ [Feat] 관심 동네 검색

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -21,9 +21,11 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_DELETE_SUCCESS(HttpStatus.OK, "MEMBER2006", "회원 탈퇴가 완료되었습니다."),
     MEMBER_PROFILE_IMAGE_UPDATED(HttpStatus.OK, "MEMBER2007", "프로필 이미지가 성공적으로 변경되었습니다."),
 
-    // 장소 저장 관련 응답
-    SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다.");
+    // 장소 저장
+    SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),
 
+    // 동네 검색
+    REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/DNBN/spring/config/QueryDSLConfig.java
+++ b/src/main/java/DNBN/spring/config/QueryDSLConfig.java
@@ -1,0 +1,15 @@
+package DNBN.spring.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDSLConfig {
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager entityManager) {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/DNBN/spring/converter/RegionConverter.java
+++ b/src/main/java/DNBN/spring/converter/RegionConverter.java
@@ -1,0 +1,18 @@
+package DNBN.spring.converter;
+
+import DNBN.spring.domain.Region;
+import DNBN.spring.web.dto.RegionResponseDTO;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RegionConverter {
+
+    public RegionResponseDTO.RegionFullNameDTO toRegionPreviewDTO(Region region) {
+        return RegionResponseDTO.RegionFullNameDTO.builder()
+                .regionId(region.getId())
+                .province(region.getProvince())
+                .city(region.getCity())
+                .district(region.getDistrict())
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepository.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepository.java
@@ -3,11 +3,5 @@ package DNBN.spring.repository.RegionRepository;
 import DNBN.spring.domain.Region;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.util.List;
-import java.util.Optional;
-
-public interface RegionRepository extends JpaRepository<Region, Long> {
-    Optional<Region> findByProvinceAndCityAndDistrict(String province, String city, String district);
-
-    List<Region> findByDistrictContaining(String keyword);
+public interface RegionRepository extends JpaRepository<Region, Long>, RegionRepositoryCustom {
 }

--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryCustom.java
@@ -1,0 +1,9 @@
+package DNBN.spring.repository.RegionRepository;
+
+import DNBN.spring.domain.Region;
+
+import java.util.List;
+
+public interface RegionRepositoryCustom {
+    List<Region> searchByKeyword(String keyword, Long cursor, int limit);
+}

--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryImpl.java
@@ -1,0 +1,41 @@
+package DNBN.spring.repository.RegionRepository;
+
+import DNBN.spring.domain.Region;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import DNBN.spring.domain.QRegion;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class RegionRepositoryImpl implements RegionRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QRegion region = QRegion.region;
+
+    @Override
+    public List<Region> searchByKeyword(String keyword, Long cursor, int limit) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (keyword != null && !keyword.isBlank()) {
+            builder.and(
+                    region.province.containsIgnoreCase(keyword)
+                            .or(region.city.containsIgnoreCase(keyword))
+                            .or(region.district.containsIgnoreCase(keyword))
+            );
+        }
+
+        if (cursor != null) {
+            builder.and(region.id.gt(cursor));
+        }
+
+        return jpaQueryFactory.selectFrom(region)
+                .where(builder)
+                .orderBy(region.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/DNBN/spring/service/RegionService/RegionQueryService.java
+++ b/src/main/java/DNBN/spring/service/RegionService/RegionQueryService.java
@@ -1,0 +1,7 @@
+package DNBN.spring.service.RegionService;
+
+import DNBN.spring.web.dto.RegionResponseDTO;
+
+public interface RegionQueryService {
+    RegionResponseDTO.SearchRegionResult searchRegion(String keyword, Long cursor, int limit);
+}

--- a/src/main/java/DNBN/spring/service/RegionService/RegionQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/RegionService/RegionQueryServiceImpl.java
@@ -1,0 +1,39 @@
+package DNBN.spring.service.RegionService;
+
+import DNBN.spring.converter.RegionConverter;
+import DNBN.spring.domain.Region;
+import DNBN.spring.repository.RegionRepository.RegionRepository;
+import DNBN.spring.web.dto.RegionResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional(readOnly = true)
+public class RegionQueryServiceImpl implements RegionQueryService {
+
+    private final RegionRepository regionRepository;
+    private final RegionConverter regionConverter;
+
+    @Override
+    public RegionResponseDTO.SearchRegionResult searchRegion(String keyword, Long cursor, int limit) {
+        List<Region> regions = regionRepository.searchByKeyword(keyword, cursor, limit);
+        List<RegionResponseDTO.RegionFullNameDTO> previews = regions.stream()
+                .map(regionConverter::toRegionPreviewDTO)
+                .toList();
+
+        Long nextCursor = previews.isEmpty() ? null : previews.get(previews.size() - 1).getRegionId();
+        boolean hasNext = previews.size() == limit;
+
+        return RegionResponseDTO.SearchRegionResult.builder()
+                .regions(previews)
+                .cursor(nextCursor)
+                .limit((long) limit)
+                .hasNext(hasNext)
+                .build();
+    }
+}
+

--- a/src/main/java/DNBN/spring/web/controller/RegionRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/RegionRestController.java
@@ -1,0 +1,35 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.service.RegionService.RegionQueryService;
+import DNBN.spring.web.dto.RegionResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/regions")
+public class RegionRestController {
+
+    private final RegionQueryService regionQueryService;
+
+    @GetMapping("/search")
+    @Operation(summary = "관심 동네 검색", description = "키워드로 관심 동네를 검색합니다.")
+    public ResponseEntity<ApiResponse<RegionResponseDTO.SearchRegionResult>> searchRegionList(
+            @Parameter(name = "keyword", description = "검색 키워드", required = true)
+            @RequestParam String keyword,
+
+            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 regionId (default: null)", example = "0")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
+            @RequestParam(defaultValue = "20") int limit
+    ) {
+        RegionResponseDTO.SearchRegionResult result = regionQueryService.searchRegion(keyword, cursor, limit);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/RegionResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/RegionResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class RegionResponseDTO {
     @Getter
     @Builder
@@ -13,5 +15,32 @@ public class RegionResponseDTO {
     public static class RegionPreviewnDTO {
         Long id;
         String name;
+    }
+
+    @Getter
+    @Builder
+    public static class RegionInfoDTO {
+        private Long regionId;
+        private String province;
+        private String city;
+        private String district;
+    }
+
+    @Getter
+    @Builder
+    public static class RegionFullNameDTO {
+        private Long regionId;
+        private String province;
+        private String city;
+        private String district;
+    }
+
+    @Getter
+    @Builder
+    public static class SearchRegionResult {
+        private List<RegionFullNameDTO> regions;
+        private Long cursor;
+        private Long limit;
+        private boolean hasNext;
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
- GET /api/regions/search 구현
- 키워드(keyword)를 기반으로 지역 정보(province, city, district)를 검색하는 API
- province, city, district 중 하나라도 keyword를 포함하면 결과에 포함되도록 QueryDSL 조건 구성

## 🛠️ 작업 상세 내용
- [x] RegionQueryService에서 searchRegion(String keyword, Long cursor, int limit) 메서드 구현
- [x] QueryDSL을 사용해 province, city, district에 keyword가 포함된 데이터를 동적 조건으로 검색
- [x] limit + 1건 조회 후 hasNext 여부 판별
- [x] cursor는 마지막으로 조회된 region의 ID로 반환
- [x] limit이나 cursor 미입력 시 기본값 자동 적용 (limit=20, cursor=null)
- [x] 무한 스크롤을 위한 cursor 기반 페이징 처리 적용

## 📸 스크린샷 (선택)
<img width="1212" height="328" alt="스크린샷 2025-07-24 오후 6 03 51" src="https://github.com/user-attachments/assets/bba2ee61-01d1-49cb-a4e8-c6b2cd62f880" />

## 💬 기타(공유사항 to 리뷰어)
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google

- limit은 20으로 기본 설정 되어있음. -> 다른 개수의 검색 결과 보고싶다면 입력하기
- hasNext가 true인 경우는 limit값 이상으로 검색 결과가 존재한다는 것 -> 파라미터 cursor에 응답받은 cursor값 입력하면 다음 검색 결과 이어서 보기 가능