### PR TITLE
✨[Feat] 댓글 및 대댓글 생성

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -72,7 +72,12 @@ public enum ErrorStatus implements BaseErrorCode {
     CATEGORY_INVALID_NAME(HttpStatus.BAD_REQUEST, "CATEGORY_400_INVALID_NAME", "카테고리 이름이 유효하지 않습니다."),
     CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "CATEGORY_404_NOT_FOUND", "해당 카테고리를 찾을 수 없습니다."),
     CATEGORY_DUPLICATE_NAME(HttpStatus.CONFLICT, "CATEGORY_409_DUPLICATE_NAME", "이미 존재하는 카테고리 이름입니다."),
-    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다.");
+    CATEGORY_ASSOCIATED_ARTICLES(HttpStatus.CONFLICT, "CATEGORY_409_ASSOCIATED_ARTICLES", "해당 카테고리에 연결된 게시물이 있어 삭제할 수 없습니다."),
+
+    // 댓글
+    COMMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "COMMENT4001", "댓글을 찾을 수 없습니다."),
+    COMMENT_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "COMMENT4002", "댓글 내용은 1~1000자여야 합니다."),
+    COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT4003", "해당 댓글에 대한 권한이 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -25,11 +25,11 @@ public enum SuccessStatus implements BaseCode {
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),
 
     // 댓글
-    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다.")
-    ;
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
 
     // 동네 검색
-    REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다.");
+    REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다.")
+    ;
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -22,7 +22,11 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_PROFILE_IMAGE_UPDATED(HttpStatus.OK, "MEMBER2007", "프로필 이미지가 성공적으로 변경되었습니다."),
 
     // 장소 저장 관련 응답
-    SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다.");
+    SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),
+
+    // 댓글
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다.")
+    ;
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CommentHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CommentHandler.java
@@ -1,0 +1,10 @@
+package DNBN.spring.apiPayload.exception.handler;
+
+import DNBN.spring.apiPayload.code.BaseErrorCode;
+import DNBN.spring.apiPayload.exception.GeneralException;
+
+public class CommentHandler extends GeneralException {
+    public CommentHandler(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/DNBN/spring/converter/CommentConverter.java
+++ b/src/main/java/DNBN/spring/converter/CommentConverter.java
@@ -1,0 +1,17 @@
+package DNBN.spring.converter;
+
+import DNBN.spring.domain.Comment;
+import DNBN.spring.web.dto.CommentResponseDTO;
+
+public class CommentConverter {
+    public static CommentResponseDTO toCommentResponseDTO(Comment comment) {
+        return CommentResponseDTO.builder()
+                .commentId(comment.getCommentId())
+                .articleId(comment.getArticle().getArticleId())
+                .content(comment.getContent())
+                .createdAt(comment.getCreatedAt().toString())
+                .updatedAt(comment.getUpdatedAt().toString())
+                .parentCommentId(comment.getParentComment() != null ? comment.getParentComment().getCommentId() : null)
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/domain/Comment.java
+++ b/src/main/java/DNBN/spring/domain/Comment.java
@@ -26,18 +26,6 @@ public class Comment extends BaseEntity {
   @JoinColumn(name = "article_id", nullable = false)
   private Article article;
 
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "member_id", nullable = false)
-  private Member member;
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "place_id", nullable = false)
-  private Place place;
-
-  @ManyToOne(fetch = FetchType.LAZY)
-  @JoinColumn(name = "region_id", nullable = false)
-  private Region region;
-
   @Builder.Default
   @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
   private Long likeCount = 0L;

--- a/src/main/java/DNBN/spring/repository/CommentRepository/CommentRepository.java
+++ b/src/main/java/DNBN/spring/repository/CommentRepository/CommentRepository.java
@@ -10,8 +10,5 @@ import java.util.List;
 
 public interface CommentRepository extends JpaRepository<Comment, Long> {
     List<Comment> findAllByArticle(Article article);
-    List<Comment> findAllByMember(Member member);
-    List<Comment> findAllByPlace(Place place);
-    List<Comment> findAllByRegion(Region region);
 }
 

--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepository.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepository.java
@@ -1,7 +1,10 @@
 package DNBN.spring.repository.RegionRepository;
 
 import DNBN.spring.domain.Region;
+import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<Region, Long>, RegionRepositoryCustom {
+  Optional<Region> findByProvinceAndCityAndDistrict(String province, String city, String district);
 }

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandService.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandService.java
@@ -1,0 +1,8 @@
+package DNBN.spring.service.CommentService;
+
+import DNBN.spring.web.dto.CommentRequestDTO;
+import DNBN.spring.web.dto.CommentResponseDTO;
+
+public interface CommentCommandService {
+    CommentResponseDTO createComment(Long memberId, Long articleId, CommentRequestDTO request);
+}

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -1,0 +1,55 @@
+package DNBN.spring.service.CommentService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.CommentHandler;
+import DNBN.spring.converter.CommentConverter;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Comment;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.repository.CommentRepository.CommentRepository;
+import DNBN.spring.web.dto.CommentRequestDTO;
+import DNBN.spring.web.dto.CommentResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class CommentCommandServiceImpl implements CommentCommandService {
+    private final ArticleRepository articleRepository;
+    private final CommentRepository commentRepository;
+
+    private static final int CONTENT_MIN_LENGTH = 2;
+    private static final int CONTENT_MAX_LENGTH = 1000;
+
+    @Override
+    public CommentResponseDTO createComment(Long memberId, Long articleId, CommentRequestDTO request) {
+
+        Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
+
+        if (request.content() == null || request.content().length() < CONTENT_MIN_LENGTH || request.content().length() > CONTENT_MAX_LENGTH) {
+            throw new CommentHandler(ErrorStatus.COMMENT_CONTENT_LENGTH_INVALID);
+        }
+
+        Comment parentComment = null;
+        if (request.parentCommentId() != null) {
+            parentComment = commentRepository.findById(request.parentCommentId())
+                    .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+            if (!parentComment.getArticle().getArticleId().equals(articleId)) {
+                throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
+            }
+        }
+        Comment comment = Comment.builder()
+                .article(article)
+                .content(request.content())
+                .parentComment(parentComment)
+                .build();
+
+        commentRepository.save(comment);
+        return CommentConverter.toCommentResponseDTO(comment);
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/CommentController.java
+++ b/src/main/java/DNBN/spring/web/controller/CommentController.java
@@ -1,0 +1,42 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.SuccessStatus;
+import DNBN.spring.domain.MemberDetails;
+import DNBN.spring.service.CommentService.CommentCommandService;
+import DNBN.spring.web.dto.CommentRequestDTO;
+import DNBN.spring.web.dto.CommentResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/articles/{articleId}/comments")
+@SecurityRequirement(name = "JWT TOKEN")
+public class CommentController {
+    private final CommentCommandService commentCommandService;
+
+    @PostMapping
+    @Operation(
+        summary = "댓글 생성",
+        description = "게시물에 댓글을 작성합니다. JWT 인증 필요.",
+        security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ApiResponse<CommentResponseDTO> createComment(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @PathVariable Long articleId,
+            @RequestBody @Valid CommentRequestDTO request
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        CommentResponseDTO response = commentCommandService.createComment(memberId, articleId, request);
+        return ApiResponse.of(SuccessStatus.COMMENT_CREATE_SUCCESS, response);
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/CommentRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/CommentRequestDTO.java
@@ -1,0 +1,6 @@
+package DNBN.spring.web.dto;
+
+public record CommentRequestDTO(
+    String content,
+    Long parentCommentId // null: 일반 댓글, not null: 대댓글
+) { }

--- a/src/main/java/DNBN/spring/web/dto/CommentResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/CommentResponseDTO.java
@@ -1,0 +1,15 @@
+package DNBN.spring.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CommentResponseDTO {
+    private Long commentId;
+    private Long articleId;
+    private String content;
+    private String createdAt;
+    private String updatedAt;
+    private Long parentCommentId;
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 댓글 생성 API 구현 (대댓글 포함). 댓글 생성 시 parentCommentId 응답 추가

## 🛠️ 작업 상세 내용
- [x] 댓글 생성 API(POST /api/articles/{articleId}/comments) 구현
- [x] 대댓글(`parentCommentId` 지정) 기능 구현
- [x] Swagger 명세 작성
- [x] 예외 처리
- [x] 테스트 시나리오 작성

## 📸 스크린샷 (선택)
**시나리오 1:**
<img width="1169" height="460" alt="image" src="https://github.com/user-attachments/assets/635feb4c-5ffe-41d5-b5c6-197336438dc1" />
<img width="1162" height="351" alt="image" src="https://github.com/user-attachments/assets/9c04fad1-8061-4233-906b-66207fec92cf" />

**시나리오 2:**
<img width="1170" height="437" alt="image" src="https://github.com/user-attachments/assets/836c4312-9a1a-49a5-a02f-5bd8b59dea6f" />
<img width="1157" height="469" alt="image" src="https://github.com/user-attachments/assets/e5ec68fc-5234-470c-93d1-9b225154b162" />
<img width="1167" height="927" alt="image" src="https://github.com/user-attachments/assets/f60ea42f-adff-4fec-9f95-9e0d51407438" />

<img width="1159" height="365" alt="image" src="https://github.com/user-attachments/assets/33a19ff2-e507-4f19-96d1-1221256d2f0a" />

**시나리오 3:**
<img width="1169" height="458" alt="image" src="https://github.com/user-attachments/assets/99c996ce-0ff1-4d54-8b22-f00fde9e5c4e" />
<img width="1154" height="363" alt="image" src="https://github.com/user-attachments/assets/8d41bfe9-4aa9-4712-a087-d8ca797b05b6" />

**시나리오 4:**
<img width="1150" height="502" alt="image" src="https://github.com/user-attachments/assets/4ce32887-1278-40b3-b2e5-a6983a1aef6b" />
<img width="1150" height="348" alt="image" src="https://github.com/user-attachments/assets/4f05b417-2dac-4d47-b716-d2436de14204" />

**시나리오 5:**
<img width="1171" height="678" alt="image" src="https://github.com/user-attachments/assets/81a80895-efd9-4506-bfb6-26a2881c690e" />
<img width="1164" height="543" alt="image" src="https://github.com/user-attachments/assets/2b699be0-1bc6-4dba-a7f4-a36267a60638" />

**시나리오 6:**
<img width="1170" height="666" alt="image" src="https://github.com/user-attachments/assets/add6402e-79f9-4242-899e-5d9adecdd646" />
<img width="1169" height="531" alt="image" src="https://github.com/user-attachments/assets/79e11829-5c6a-4c4f-acb9-7f08f844bfe4" />

## 💬 기타(공유사항 to 리뷰어)
- `Comment`의 외래키를 `article_id`만 남기고 제거하였습니다.
- 마이그레이션으로 테이블 필드와 제약 조건도 같이 제거하였습니다.
### 테스트에 필요한 링크
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google

### 테스트 시나리오
| 시나리오 번호 | 입력 조건 | 기대 결과 (예외/성공) | 예외 코드/메시지 또는 SuccessStatus |
|---|---|---|---|
| 1 | 존재하지 않는 articleId | ArticleHandler 예외 발생 | ARTICLE4001 |
| 2 | content가 null, 2자 미만, 1000자 초과 | CommentHandler 예외 발생 | COMMENT4002 |
| 3 | parentCommentId가 존재하지 않는 값 | CommentHandler 예외 발생 | COMMENT4001 |
| 4 | parentCommentId의 articleId와 요청 articleId가 다름 | CommentHandler 예외 발생 | COMMENT4003 |
| 5 | 정상 댓글 생성 (parentCommentId=null 또는 미포함) | 댓글 정상 생성, parentCommentId=null | COMMENT_CREATE_SUCCESS |
| 6 | 정상 대댓글 생성 (parentCommentId=존재하는 댓글 id) | 대댓글 정상 생성, parentCommentId=부모댓글id | COMMENT_CREATE_SUCCESS |