### PR TITLE
🚑  [Hotfix] 배포 후 소셜 로그인

### DIFF
--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -44,8 +44,10 @@ public class SecurityConfig {
 
         // 동네방네 프론트, 백엔드 로컬, 운영 도메인 등 실제 사용하는 도메인 입력
         config.setAllowedOrigins(List.of(
-//                "https://", // 프론트 도메인
-//                "https://", // 백엔드 도메인
+                "https://dnbn.site", // 프론트 도메인
+                "https://api.dnbn.site", // 백엔드 도메인
+                "http://3.36.90.173:3000",
+                "http://3.36.90.173:8080",
                 "http://localhost:3000", // 로컬 프론트
                 "http://localhost:8080" // 로컬 백엔드
         ));
@@ -66,7 +68,7 @@ public class SecurityConfig {
                 .httpBasic(HttpBasicConfigurer::disable)
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정 추가
                 .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT 사용 시 STATELESS
                 )
                 .authorizeHttpRequests(
                         (requests) -> requests

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao
@@ -37,7 +37,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_SECRET}
-            redirect-uri: ${NAVER_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope:
             client-name: Naver
@@ -45,7 +45,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_SECRET}
-            redirect-uri: ${GOOGLE_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope:
               - openid
@@ -79,6 +79,7 @@ spring:
       #   - 이 경우 파일 크기 초과 등 예외가 ExceptionHandler까지 도달하지 않고, 더 앞단(서블릿 컨테이너 등)에서 처리됨
       resolve-lazily: false
 server:
+  forward-headers-strategy: framework
   tomcat:
     max-swallow-size: 200MB
 jwt:


### PR DESCRIPTION
## #️⃣ 기능 설명
> 배포 전 localhost:8080에서 카카오/네이버/구글 소셜 로그인 모두 원하는대로 동작했음(백엔드 모두 확인함) -> 서버 배포 후 그에 따라 배포 주소와 도메인 등을 적용해도 소셜 로그인이 안됨

## 🛠️ 작업 상세 내용
- [ ] 카카오/네아버/구글 배포 주소로

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
다들 머지하심 안 됩니다!!

각 소셜 디벨로퍼에서 배포 주소 추가하고,
깃허브의 secret and variables의 yml값 수정해서 해결함!
(도메인도 추가하고 확인함!)