### PR TITLE
✨ [Feat] 해당 카테고리에 저장된 장소 조회

### DIFF
--- a/src/main/java/DNBN/spring/converter/PlaceConverter.java
+++ b/src/main/java/DNBN/spring/converter/PlaceConverter.java
@@ -1,0 +1,26 @@
+package DNBN.spring.converter;
+
+import DNBN.spring.domain.mapping.SavePlace;
+import DNBN.spring.web.dto.PlaceResponseDTO;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class PlaceConverter {
+
+    public static PlaceResponseDTO.SavedPlacePreviewDTO toSavedPlacePreviewDTO(SavePlace savePlace) {
+        return PlaceResponseDTO.SavedPlacePreviewDTO.builder()
+                .placeId(savePlace.getPlace().getPlaceId())
+                .title(savePlace.getPlace().getTitle())
+                .pinCategory(savePlace.getPlace().getPinCategory().name())
+                .latitude(savePlace.getPlace().getLatitude())
+                .longitude(savePlace.getPlace().getLongitude())
+                .build();
+    }
+
+    public static List<PlaceResponseDTO.SavedPlacePreviewDTO> toSavedPlacePreviewDTOList(List<SavePlace> savePlaces) {
+        return savePlaces.stream()
+                .map(PlaceConverter::toSavedPlacePreviewDTO)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
-public interface SavePlaceRepository extends JpaRepository<SavePlace, Long> {
+public interface SavePlaceRepository extends JpaRepository<SavePlace, Long>, SavePlaceRepositoryCustom {
     List<SavePlace> findByCategory(Category category);
-    boolean existsByPlaceAndCategory(Place place, Category category); // 중복 체크
+    boolean existsByPlaceAndCategory(Place place, Category category);
 }

--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryCustom.java
@@ -1,0 +1,9 @@
+package DNBN.spring.repository.SavePlaceRepository;
+
+import DNBN.spring.domain.mapping.SavePlace;
+
+import java.util.List;
+
+public interface SavePlaceRepositoryCustom {
+    List<SavePlace> findSavedPlaces(Long categoryId, Long cursor, Long limit);
+}

--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryImpl.java
@@ -1,0 +1,35 @@
+package DNBN.spring.repository.SavePlaceRepository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import DNBN.spring.domain.mapping.QSavePlace;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import DNBN.spring.domain.mapping.SavePlace;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class SavePlaceRepositoryImpl implements SavePlaceRepositoryCustom {
+
+    private final JPAQueryFactory jpaQueryFactory;
+    private final QSavePlace savePlace = QSavePlace.savePlace;
+
+    @Override
+    public List<SavePlace> findSavedPlaces(Long categoryId, Long cursor, Long limit) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(savePlace.category.categoryId.eq(categoryId));
+
+        if (cursor != null) {
+            builder.and(savePlace.id.gt(cursor));
+        }
+
+        return jpaQueryFactory.selectFrom(savePlace)
+                .where(builder)
+                .orderBy(savePlace.id.asc())
+                .limit(limit)
+                .fetch();
+    }
+}

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryService.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryService.java
@@ -1,0 +1,7 @@
+package DNBN.spring.service.PlaceService;
+
+import DNBN.spring.web.dto.PlaceResponseDTO;
+
+public interface PlaceQueryService {
+    PlaceResponseDTO.SavedPlaceListDTO getSavedPlaces(Long categoryId, Long memberId, Long cursor, Long limit);
+}

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
@@ -1,0 +1,52 @@
+package DNBN.spring.service.PlaceService;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.CategoryHandler;
+import DNBN.spring.converter.PlaceConverter;
+import DNBN.spring.domain.Category;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Place;
+import DNBN.spring.domain.mapping.SavePlace;
+import DNBN.spring.repository.CategoryRepository.CategoryRepository;
+import DNBN.spring.repository.SavePlaceRepository.SavePlaceRepository;
+import DNBN.spring.repository.SavePlaceRepository.SavePlaceRepositoryImpl;
+import DNBN.spring.web.dto.PlaceResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class PlaceQueryServiceImpl implements PlaceQueryService {
+
+    private final CategoryRepository categoryRepository;
+    private final SavePlaceRepository savePlaceRepository;
+
+    @Override
+    public PlaceResponseDTO.SavedPlaceListDTO getSavedPlaces(Long categoryId, Long memberId, Long cursor, Long limit) {
+        // 1. 카테고리 본인 것인지 확인
+        Category category = categoryRepository
+                .findByCategoryIdAndMemberAndDeletedAtIsNull(categoryId, Member.builder().id(memberId).build())
+                .orElseThrow(() -> new CategoryHandler(ErrorStatus._FORBIDDEN));
+
+        // 2. 저장된 장소 조회 (커서 기반)
+        List<SavePlace> savePlaces = savePlaceRepository.findSavedPlaces(categoryId, cursor, limit + 1);
+
+        boolean hasNext = savePlaces.size() > limit;
+        if (hasNext) savePlaces.remove(savePlaces.size() - 1);
+
+        // 3. 변환 (컨버터 사용)
+        List<PlaceResponseDTO.SavedPlacePreviewDTO> places = PlaceConverter.toSavedPlacePreviewDTOList(savePlaces);
+        Long nextCursor = savePlaces.isEmpty() ? null : savePlaces.get(savePlaces.size() - 1).getId();
+
+        return PlaceResponseDTO.SavedPlaceListDTO.builder()
+                .places(places)
+                .cursor(nextCursor)
+                .limit(limit)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
@@ -7,9 +7,11 @@ import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.service.PlaceService.PlaceCommandService;
+import DNBN.spring.service.PlaceService.PlaceQueryService;
 import DNBN.spring.web.dto.PlaceRequestDTO;
 import DNBN.spring.web.dto.PlaceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -26,6 +28,7 @@ public class PlaceRestController {
     private final PlaceCommandService placeCommandService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final PlaceQueryService placeQueryService;
 
     @Operation(summary = "장소 카테고리에 저장", description = "장소를 사용자의 카테고리에 저장합니다.")
     @PostMapping("/{placeId}/categories")
@@ -36,6 +39,24 @@ public class PlaceRestController {
 
         Long memberId = extractMemberIdFromToken(request);
         PlaceResponseDTO.SavePlaceResultDTO response = placeCommandService.savePlaceToCategory(memberId, placeId, dto);
+        return ResponseEntity.ok(ApiResponse.onSuccess(response));
+    }
+
+    @Operation(summary = "카테고리에 저장된 장소 목록 조회", description = "해당 카테고리에 저장된 장소들을 조회합니다.")
+    @GetMapping("/categories/{categoryId}/places")
+    public ResponseEntity<ApiResponse<PlaceResponseDTO.SavedPlaceListDTO>> getSavedPlacesByCategory(
+            @PathVariable Long categoryId,
+
+            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 ID (save_place PK) (default: null)", example = "0")
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
+            @RequestParam(defaultValue = "20") Long limit,
+
+            HttpServletRequest request
+    ) {
+        Long memberId = extractMemberIdFromToken(request);
+        PlaceResponseDTO.SavedPlaceListDTO response = placeQueryService.getSavedPlaces(categoryId, memberId, cursor, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 

--- a/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
@@ -47,7 +47,7 @@ public class PlaceRestController {
     public ResponseEntity<ApiResponse<PlaceResponseDTO.SavedPlaceListDTO>> getSavedPlacesByCategory(
             @PathVariable Long categoryId,
 
-            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 ID (save_place PK) (default: null)", example = "0")
+            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 ID (save_place PK) (default: null) -> 응답받은 cursor 값 넣어주면 됨", example = "0")
             @RequestParam(required = false) Long cursor,
 
             @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")

--- a/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
@@ -5,6 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 public class PlaceResponseDTO {
     @Getter
     @Builder
@@ -13,5 +15,24 @@ public class PlaceResponseDTO {
     public static class SavePlaceResultDTO {
         private Long placeId;
         private Long categoryId;
+    }
+
+    @Getter
+    @Builder
+    public static class SavedPlacePreviewDTO {
+        private Long placeId;
+        private String title;
+        private String pinCategory;
+        private Double latitude;
+        private Double longitude;
+    }
+
+    @Getter
+    @Builder
+    public static class SavedPlaceListDTO {
+        private List<SavedPlacePreviewDTO> places;
+        private Long cursor;
+        private Long limit;
+        private boolean hasNext;
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
- 사용자가 본인 카테고리에 저장한 장소 목록을 커서 기반으로 조회하는 API 구현
- GET /api/places/categories/{categoryId}/places

## 🛠️ 작업 상세 내용
- [x] JWT 인증을 통해 요청자의 사용자 ID 추출 후 해당 사용자의 카테고리 여부 검증
- [x] PlaceQueryServiceImpl: 카테고리 소유자 검증 및 커서 기반 조회 로직 구현
- [x] SavePlaceRepositoryImpl: save_place.id 기준 정렬 및 페이징 처리
- [x] PlaceConverter: SavePlace → SavedPlacePreviewDTO 리스트 변환 로직 분리
- [x] Controller에서 JWT 인증 처리 및 Swagger 문서 설명 추가

## 📸 스크린샷 (선택)
<img width="1192" height="392" alt="스크린샷 2025-07-26 오후 4 56 27" src="https://github.com/user-attachments/assets/818767fe-9e1e-432e-a41b-d050367ba3d2" />

<img width="1200" height="182" alt="스크린샷 2025-07-26 오후 4 56 38" src="https://github.com/user-attachments/assets/ae6e3faf-194b-44ba-a1b9-28fe7bb94b13" />


## 💬 기타(공유사항 to 리뷰어)
- 커서 없이 요청 시 첫 20개 이하 반환 확인
- 커서와 limit을 지정한 페이지 요청 시 페이징 동작 정상 확인
- 다른 사용자의 카테고리에 접근 시 4003 에러 반환 확인