### PR TITLE
♻️ [Refactor] 소셜 로그인 정보 쿠키로 내려주기

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -15,6 +15,8 @@ public enum ErrorStatus implements BaseErrorCode {
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON4001","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON4003", "금지된 요청입니다."),
 
+    ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMON4004", "권한이 없습니다."),
+
     // 멤버 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수입니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -53,6 +53,8 @@ public enum ErrorStatus implements BaseErrorCode {
 
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "유효하지 않은 SocialToken입니다."),
 
+    INVALID_CSRF_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4004", "유효하지 않은 CSRF Token입니다."),
+
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
 
     // 장소 저장 에러

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAccessDeniedHandler.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.security.web.csrf.InvalidCsrfTokenException;
@@ -15,6 +16,7 @@ import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
+@Slf4j
 @Component
 public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인증은 되었으나 권한이 없을 때의 403 에러를 반환
     @Override
@@ -22,7 +24,7 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인�
                        HttpServletResponse response,
                        AccessDeniedException accessDeniedException) throws IOException, ServletException {
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
 
         ErrorReasonDTO reason;
@@ -42,6 +44,10 @@ public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인�
                     .message(ErrorStatus.ACCESS_DENIED.getMessage())
                     .build();
         }
+        log.warn("❗ AccessDeniedException 발생 - 클래스: {}", accessDeniedException.getClass().getName());
+        log.warn("❗ AccessDeniedException 메시지: {}", accessDeniedException.getMessage(), accessDeniedException);
+        log.error("❌ [AccessDenied] URI: {}, Method: {}",
+                request.getRequestURI(), request.getMethod());
 
         response.getWriter().write(new ObjectMapper().writeValueAsString(
                 ApiResponse.onFailure(reason.getCode(), reason.getMessage(), reason)

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAccessDeniedHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAccessDeniedHandler.java
@@ -1,0 +1,50 @@
+package DNBN.spring.apiPayload.exception.handler;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.ErrorReasonDTO;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.security.web.csrf.InvalidCsrfTokenException;
+import org.springframework.security.web.csrf.MissingCsrfTokenException;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler { // 인증은 되었으나 권한이 없을 때의 403 에러를 반환
+    @Override
+    public void handle(HttpServletRequest request,
+                       HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType("application/json;charset=UTF-8");
+
+        ErrorReasonDTO reason;
+
+        if (accessDeniedException instanceof InvalidCsrfTokenException || accessDeniedException instanceof MissingCsrfTokenException) {
+            reason = ErrorReasonDTO.builder()
+                    .httpStatus(ErrorStatus.INVALID_CSRF_TOKEN.getHttpStatus())
+                    .isSuccess(false)
+                    .code(ErrorStatus.INVALID_CSRF_TOKEN.getCode())
+                    .message(ErrorStatus.INVALID_CSRF_TOKEN.getMessage())
+                    .build();
+        } else {
+            reason = ErrorReasonDTO.builder()
+                    .httpStatus(ErrorStatus.ACCESS_DENIED.getHttpStatus())
+                    .isSuccess(false)
+                    .code(ErrorStatus.ACCESS_DENIED.getCode())
+                    .message(ErrorStatus.ACCESS_DENIED.getMessage())
+                    .build();
+        }
+
+        response.getWriter().write(new ObjectMapper().writeValueAsString(
+                ApiResponse.onFailure(reason.getCode(), reason.getMessage(), reason)
+        ));
+    }
+}

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
@@ -19,7 +19,7 @@ public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint 
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.setContentType("application/json;charset=UTF-8");
 
         ErrorReasonDTO reason = ErrorReasonDTO.builder()

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CustomAuthenticationEntryPoint.java
@@ -13,13 +13,13 @@ import org.springframework.stereotype.Component;
 import java.io.IOException;
 
 @Component
-public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint { // 인증 실패 시 401 에러를 반환
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
                          AuthenticationException authException) throws IOException {
 
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
         response.setContentType("application/json;charset=UTF-8");
 
         ErrorReasonDTO reason = ErrorReasonDTO.builder()

--- a/src/main/java/DNBN/spring/config/SwaggerConfig.java
+++ b/src/main/java/DNBN/spring/config/SwaggerConfig.java
@@ -46,7 +46,7 @@ public class SwaggerConfig {
                 pathItem.readOperations().forEach(operation -> {
                     operation.addParametersItem(new Parameter()
                             .in("header")
-                            .name("X-XSRF-TOKEN")
+                            .name("X-XSRF-TOKEN") // XSRF-TOKEN라는 이름이 Spring Security에서 기본적으로 정한 CSRF 토큰 쿠키 표준이라 함
                             .required(false)
                             .schema(new StringSchema())
                             .description("CSRF 보호를 위한 토큰. XSRF-TOKEN 쿠키 값을 읽어서 설정해야 합니다."));

--- a/src/main/java/DNBN/spring/config/SwaggerConfig.java
+++ b/src/main/java/DNBN/spring/config/SwaggerConfig.java
@@ -1,11 +1,14 @@
 package DNBN.spring.config;
 
+import io.swagger.v3.oas.models.parameters.Parameter;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.StringSchema;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
+import org.springdoc.core.customizers.OpenApiCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 

--- a/src/main/java/DNBN/spring/config/SwaggerConfig.java
+++ b/src/main/java/DNBN/spring/config/SwaggerConfig.java
@@ -38,4 +38,20 @@ public class SwaggerConfig {
                 .addSecurityItem(securityRequirement)
                 .components(components);
     }
+
+    @Bean
+    public OpenApiCustomizer csrfHeaderCustomizer() {
+        return openApi -> {
+            openApi.getPaths().forEach((path, pathItem) -> {
+                pathItem.readOperations().forEach(operation -> {
+                    operation.addParametersItem(new Parameter()
+                            .in("header")
+                            .name("X-XSRF-TOKEN")
+                            .required(false)
+                            .schema(new StringSchema())
+                            .description("CSRF 보호를 위한 토큰. XSRF-TOKEN 쿠키 값을 읽어서 설정해야 합니다."));
+                });
+            });
+        };
+    }
 }

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -82,11 +82,12 @@ public class SecurityConfig {
                 )
 //                .csrf()
 //                .disable()
-//                .csrf(AbstractHttpConfigurer::disable)
-                .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
-                        .ignoringRequestMatchers("/api/auth/**") // GET은 자동으로 제외됨
-                )
+                .csrf(AbstractHttpConfigurer::disable)
+                // 배포 시 아래 코드 주석 해제
+//                .csrf(csrf -> csrf
+//                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
+//                        .ignoringRequestMatchers("/api/auth/**") // GET은 자동으로 제외됨
+//                )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
                                 .oidcUserService(customOidcUserService) // 구글

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -74,7 +74,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(
                         (requests) -> requests
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                                .requestMatchers("/", "/auth/reissue", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/", "/api/auth/reissue", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
 //                                .requestMatchers("/admin/**").hasRole("ADMIN") // pm이 ADMIN역할 기능 필요 X
                                 .anyRequest().authenticated()
                 )
@@ -83,7 +83,7 @@ public class SecurityConfig {
 //                .csrf(AbstractHttpConfigurer::disable)
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
-                        .ignoringRequestMatchers("api/auth/**") // GET은 자동으로 제외됨
+                        .ignoringRequestMatchers("/api/auth/**") // GET은 자동으로 제외됨
                 )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -82,7 +82,7 @@ public class SecurityConfig {
 //                .disable()
 //                .csrf(AbstractHttpConfigurer::disable)
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
                         .ignoringRequestMatchers("api/auth/**") // GET은 자동으로 제외됨
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -1,5 +1,6 @@
 package DNBN.spring.config.security;
 
+import DNBN.spring.apiPayload.exception.handler.CustomAccessDeniedHandler;
 import DNBN.spring.apiPayload.exception.handler.CustomAuthenticationEntryPoint;
 import DNBN.spring.config.security.jwt.JwtAuthenticationFilter;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
@@ -38,6 +39,7 @@ public class SecurityConfig {
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
+    private final CustomAccessDeniedHandler customAccessDeniedHandler;
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() { // CORS 설정
@@ -94,7 +96,8 @@ public class SecurityConfig {
                         .failureHandler(oAuth2FailureHandler)
                 )
                 .exceptionHandling(exception -> exception
-                        .authenticationEntryPoint(customAuthenticationEntryPoint)
+                        .authenticationEntryPoint(customAuthenticationEntryPoint) // 인증 실패 처리 (401)
+                        .accessDeniedHandler(customAccessDeniedHandler) // 권한 거부 및 CSRF 예외 처리 (403)
                 )
 //                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
                 .addFilterBefore(jwtAuthenticationFilter(), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -44,8 +44,10 @@ public class SecurityConfig {
 
         // 동네방네 프론트, 백엔드 로컬, 운영 도메인 등 실제 사용하는 도메인 입력
         config.setAllowedOrigins(List.of(
-//                "https://", // 프론트 도메인
-//                "https://", // 백엔드 도메인
+                "https://dnbn.site", // 프론트 도메인
+                "https://api.dnbn.site", // 백엔드 도메인
+                "http://3.36.90.173:3000",
+                "http://3.36.90.173:8080",
                 "http://localhost:3000", // 로컬 프론트
                 "http://localhost:8080" // 로컬 백엔드
         ));
@@ -66,7 +68,7 @@ public class SecurityConfig {
                 .httpBasic(HttpBasicConfigurer::disable)
                 .cors(corsConfigurer -> corsConfigurer.configurationSource(corsConfigurationSource())) // CORS 설정 추가
                 .sessionManagement(session ->
-                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // JWT 사용 시 STATELESS
                 )
                 .authorizeHttpRequests(
                         (requests) -> requests

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -20,6 +20,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -79,7 +80,11 @@ public class SecurityConfig {
                 )
 //                .csrf()
 //                .disable()
-                .csrf(AbstractHttpConfigurer::disable)
+//                .csrf(AbstractHttpConfigurer::disable)
+                .csrf(csrf -> csrf
+                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
+                        .ignoringRequestMatchers("api/auth/**") // GET은 자동으로 제외됨
+                )
                 .oauth2Login(oauth2 -> oauth2
                         .userInfoEndpoint(userInfo -> userInfo
                                 .oidcUserService(customOidcUserService) // 구글

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // 필터 �
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         log.info("🔥 [JWT 필터 제외 검사]: {}", request.getRequestURI());
-        return request.getRequestURI().equals("api/auth/reissue");
+        return request.getRequestURI().equals("/api/auth/reissue");
 //        return NO_FILTER_URIS.contains(request.getRequestURI()); // /auth/reissue 외에도 필요하면
 //        return super.shouldNotFilter(request);
     }

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package DNBN.spring.config.security.jwt;
 import DNBN.spring.config.properties.Constants;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -48,10 +49,21 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // 필터 �
     }
 
     private String resolveToken(HttpServletRequest request) { // 순수 토큰을 반환
+        // 1. 우선 Authorization 헤더 확인
         String bearerToken = request.getHeader(Constants.AUTH_HEADER);
         if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
             return bearerToken.substring(Constants.TOKEN_PREFIX.length());
         }
+
+        // 2. Authorization 헤더가 없다면 쿠키에서 accessToken 찾기
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("accessToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtAuthenticationFilter.java
@@ -26,7 +26,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter { // 필터 �
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         log.info("🔥 [JWT 필터 제외 검사]: {}", request.getRequestURI());
-        return request.getRequestURI().equals("/auth/reissue");
+        return request.getRequestURI().equals("api/auth/reissue");
 //        return NO_FILTER_URIS.contains(request.getRequestURI()); // /auth/reissue 외에도 필요하면
 //        return super.shouldNotFilter(request);
     }

--- a/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
+++ b/src/main/java/DNBN/spring/config/security/jwt/JwtTokenProvider.java
@@ -12,6 +12,7 @@ import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -124,6 +125,21 @@ public class JwtTokenProvider { // JWT 토큰을 생성하고, 검증하고, 인
         String bearerToken = request.getHeader(Constants.AUTH_HEADER);
         if(StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
             return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        return null;
+    }
+
+    public String resolveRefreshToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader(Constants.AUTH_HEADER);
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(Constants.TOKEN_PREFIX)) {
+            return bearerToken.substring(Constants.TOKEN_PREFIX.length());
+        }
+        if (request.getCookies() != null) {
+            for (Cookie cookie : request.getCookies()) {
+                if ("refreshToken".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
         }
         return null;
     }

--- a/src/main/java/DNBN/spring/service/AuthService/AuthCommandService.java
+++ b/src/main/java/DNBN/spring/service/AuthService/AuthCommandService.java
@@ -1,7 +1,11 @@
 package DNBN.spring.service.AuthService;
 
 import DNBN.spring.web.dto.AuthResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.web.csrf.CsrfToken;
 
 public interface AuthCommandService {
     AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken);
+    CsrfToken generateCsrfToken(HttpServletRequest request, HttpServletResponse response);
 }

--- a/src/main/java/DNBN/spring/service/AuthService/AuthCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/AuthService/AuthCommandServiceImpl.java
@@ -6,8 +6,13 @@ import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.web.dto.AuthResponseDTO;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
+import org.springframework.security.web.csrf.HttpSessionCsrfTokenRepository;
 import org.springframework.stereotype.Service;
 import DNBN.spring.domain.MemberDetails;
 import DNBN.spring.converter.AuthConverter;
@@ -18,6 +23,8 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+
+    private final CsrfTokenRepository csrfTokenRepository = new HttpSessionCsrfTokenRepository();
 
     @Override
     public AuthResponseDTO.ReissueTokenResponseDTO reissue(String refreshToken) {
@@ -50,5 +57,11 @@ public class AuthCommandServiceImpl implements AuthCommandService {
 
         // 5. DTO 변환은 컨버터에 위임
         return AuthConverter.toReissueTokenResponseDTO(newAccessToken);
+    }
+
+    public CsrfToken generateCsrfToken(HttpServletRequest request, HttpServletResponse response) { // CSRF 토큰 생성 및 저장 메서드 추가
+        CsrfToken csrfToken = csrfTokenRepository.generateToken(request);
+        csrfTokenRepository.saveToken(csrfToken, request, response);
+        return csrfToken;
     }
 }

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
@@ -3,13 +3,14 @@ package DNBN.spring.service.MemberService;
 import DNBN.spring.domain.Member;
 import DNBN.spring.web.dto.MemberRequestDTO;
 import DNBN.spring.web.dto.MemberResponseDTO;
+import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
 public interface MemberCommandService {
     Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage);
-    void logout(Long memberId);
+    void logout(HttpServletResponse response, Long memberId);
     void deleteMember(Long memberId);
     void changeMemberNickname(Long memberId, String newNickname);
     MemberResponseDTO.ChosenRegionsDTO updateRegions(Long memberId, List<Long> regionIds);

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -125,10 +125,21 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .sameSite("Lax")
                 .build();
 
+        // CSRF 토큰 쿠키 삭제
+        ResponseCookie deleteCsrfCookie = ResponseCookie.from("XSRF-TOKEN", "")
+                .httpOnly(false) // 일반 쿠키라 false
+                .secure(true)
+                .path("/")
+                .domain("dnbn.site")
+                .maxAge(0)
+                .sameSite("Lax")
+                .build();
+
         response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());
         response.addHeader("Set-Cookie", deleteRefreshTokenCookie.toString());
+        response.addHeader("Set-Cookie", deleteCsrfCookie.toString());
 
-        log.info("사용자 {} 로그아웃 처리 및 refreshToken 쿠키 삭제 완료", member.getId());
+        log.info("사용자 {} 로그아웃 처리 및 JWT와 CSRF 쿠키 삭제 완료", member.getId());
     }
 
     @Override

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -130,7 +130,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .httpOnly(false) // 일반 쿠키라 false
                 .secure(true)
                 .path("/")
-                .domain("dnbn.site")
+                .domain("dnbn.site") // 테스트 시 주석처리
                 .maxAge(0)
                 .sameSite("Lax")
                 .build();

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
@@ -26,11 +26,11 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 //        response.sendRedirect(targetUrl);
 
         // JSON 응답 방식
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
-        response.getWriter().write("{\"success\": false, \"message\": \"" + exception.getMessage() + "\"}");
+//        response.setContentType("application/json;charset=UTF-8");
+//        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+//        response.getWriter().write("{\"success\": false, \"message\": \"" + exception.getMessage() + "\"}");
 
-        /*
+        /**/
         // 쿠키로 프론트에게 내려주기
         // 1. 실패 상태 쿠키 설정 (HttpOnly false → JS에서 읽음)
         addCookie(response, "isSuccess", "false", false, 60);
@@ -39,17 +39,18 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
         // 2. 실패용 브릿지 페이지로 리다이렉트
         response.sendRedirect("https://dnbn.com/auth-bridge");
-        */
+
     }
 
-    /*
+    /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
         Cookie cookie = new Cookie(name, value);
         cookie.setHttpOnly(httpOnly);
         cookie.setSecure(true); // 운영환경 HTTPS에서는 true로 유지
         cookie.setPath("/");
+        cookie.setDomain("dnbn.site");
         cookie.setMaxAge(maxAgeInSeconds);
         response.addCookie(cookie);
     }
-    */
+
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -44,13 +45,23 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
     /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(httpOnly);
-        cookie.setSecure(true); // 운영환경 HTTPS에서는 true로 유지
-        cookie.setPath("/");
-        cookie.setDomain("dnbn.site");
-        cookie.setMaxAge(maxAgeInSeconds);
-        response.addCookie(cookie);
+//        Cookie cookie = new Cookie(name, value);
+//        cookie.setHttpOnly(httpOnly);
+//        cookie.setSecure(true); // 운영환경 HTTPS에서는 true로 유지
+//        cookie.setPath("/");
+//        cookie.setDomain("dnbn.site");
+//        cookie.setMaxAge(maxAgeInSeconds);
+//        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(true)
+                .path("/")
+                .domain("dnbn.site")
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
@@ -43,7 +43,6 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
     }
 
-    /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
 //        Cookie cookie = new Cookie(name, value);
 //        cookie.setHttpOnly(httpOnly);
@@ -63,5 +62,4 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
 
         response.addHeader("Set-Cookie", cookie.toString());
     }
-
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
@@ -39,7 +39,7 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
         addCookie(response, "message", java.net.URLEncoder.encode(exception.getMessage(), java.nio.charset.StandardCharsets.UTF_8), false, 60);
 
         // 2. 실패용 브릿지 페이지로 리다이렉트
-        response.sendRedirect("https://dnbn.com/auth-bridge");
+        response.sendRedirect("https://dnbn.com/oauth-redirect");
 
     }
 

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -48,12 +48,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         String accessToken = jwtTokenProvider.generateAccessToken(authentication); // kakao_12345
         String refreshToken = jwtTokenProvider.generateRefreshToken(member.getSocialId());
 
-        AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
-                .accessToken(accessToken)
-                .refreshToken(refreshToken)
-                .memberId(member.getId())
-                .isOnboardingCompleted(member.isOnboardingCompleted())
-                .build();
+//        AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
+//                .accessToken(accessToken)
+//                .refreshToken(refreshToken)
+//                .memberId(member.getId())
+//                .isOnboardingCompleted(member.isOnboardingCompleted())
+//                .build();
 
         // 리다이렉트 + 쿼리파라미터 방식: 프론트엔드가 토큰 읽을 수 있도록 전달 -> url에 토큰 노출
 //        String redirectUri = member.isOnboardingCompleted()
@@ -77,7 +77,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 //        response.setStatus(HttpServletResponse.SC_OK);
 //        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
 
-        /**/
         // 쿠키로 프론트에게 내려주기
         boolean isOnboardingCompleted = member.isOnboardingCompleted();
         SuccessStatus status = isOnboardingCompleted
@@ -105,7 +104,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .httpOnly(false)
                 .secure(true)
                 .path("/")
-                .domain("dnbn.site")
+                .domain("dnbn.site") // 로컬 테스트 시 주석 처리해야 함
                 .maxAge(60 * 60)
                 .sameSite("Lax")
                 .build();
@@ -117,7 +116,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     }
 
-    /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
 //        Cookie cookie = new Cookie(name, value);
 //        cookie.setHttpOnly(httpOnly);
@@ -137,5 +135,4 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         response.addHeader("Set-Cookie", cookie.toString());
     }
-
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -12,6 +12,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
@@ -98,13 +99,23 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
-        Cookie cookie = new Cookie(name, value);
-        cookie.setHttpOnly(httpOnly);
-        cookie.setSecure(true); // 운영환경에서는 true (HTTPS)
-        cookie.setPath("/");
-        cookie.setDomain("dnbn.site");
-        cookie.setMaxAge(maxAgeInSeconds);
-        response.addCookie(cookie);
+//        Cookie cookie = new Cookie(name, value);
+//        cookie.setHttpOnly(httpOnly);
+//        cookie.setSecure(true); // 운영환경에서는 true (HTTPS)
+//        cookie.setPath("/");
+//        cookie.setDomain("dnbn.site");
+//        cookie.setMaxAge(maxAgeInSeconds);
+//        response.addCookie(cookie);
+        ResponseCookie cookie = ResponseCookie.from(name, value)
+                .httpOnly(httpOnly)
+                .secure(true)
+                .path("/")
+                .domain("dnbn.site")
+                .maxAge(maxAgeInSeconds)
+                .sameSite("Lax")
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
     }
 
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -62,18 +62,18 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 //        response.sendRedirect(redirectUri);
 
         // JSON 응답 방식 (SPA 등 API 호출용)
-        ApiResponse<AuthResponseDTO.LoginResultDTO> apiResponse;
-        if (member.isOnboardingCompleted()) {
-            apiResponse = ApiResponse.of(SuccessStatus.MEMBER_ALREADY_LOGIN, result);
-        } else {
-            apiResponse = ApiResponse.of(SuccessStatus.MEMBER_NEEDS_ONBOARDING, result);
-        }
+//        ApiResponse<AuthResponseDTO.LoginResultDTO> apiResponse;
+//        if (member.isOnboardingCompleted()) {
+//            apiResponse = ApiResponse.of(SuccessStatus.MEMBER_ALREADY_LOGIN, result);
+//        } else {
+//            apiResponse = ApiResponse.of(SuccessStatus.MEMBER_NEEDS_ONBOARDING, result);
+//        }
+//
+//        response.setContentType("application/json;charset=UTF-8");
+//        response.setStatus(HttpServletResponse.SC_OK);
+//        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
 
-        response.setContentType("application/json;charset=UTF-8");
-        response.setStatus(HttpServletResponse.SC_OK);
-        response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
-
-        /*
+        /**/
         // 쿠키로 프론트에게 내려주기
         boolean isOnboardingCompleted = member.isOnboardingCompleted();
         SuccessStatus status = isOnboardingCompleted
@@ -84,7 +84,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
         addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
         addCookie(response, "memberId", String.valueOf(member.getId()), true, 60 * 60 * 4);
-        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), true, 60 * 60 * 4);
+        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), false, 60 * 60 * 4);
 
         // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
         addCookie(response, "isSuccess", "true", false, 60);
@@ -93,17 +93,18 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
         // 3. 리다이렉트 (브릿지 페이지)
         response.sendRedirect("https://dnbn.com/auth-bridge");
-        */
+
     }
 
-    /*
+    /**/
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {
         Cookie cookie = new Cookie(name, value);
         cookie.setHttpOnly(httpOnly);
         cookie.setSecure(true); // 운영환경에서는 true (HTTPS)
         cookie.setPath("/");
+        cookie.setDomain("dnbn.site");
         cookie.setMaxAge(maxAgeInSeconds);
         response.addCookie(cookie);
     }
-    */
+
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -93,7 +93,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
 
         // 3. 리다이렉트 (브릿지 페이지)
-        response.sendRedirect("https://dnbn.com/auth-bridge");
+        response.sendRedirect("https://dnbn.com/oauth-redirect");
 
     }
 

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -66,15 +66,16 @@ public class AuthRestController {
                 .httpOnly(false)    // JS에서 읽을 수 있어야 함
                 .secure(true)
                 .path("/")
-                .domain("dnbn.site")
-                .maxAge(60 * 60)    // 1시간, 필요 시 조절
+                .domain("dnbn.site") // 테스트 시 주석처리
+                .maxAge(60 * 60 * 4) // 4시간
                 .sameSite("Lax")
                 .build();
         response.addHeader("Set-Cookie", csrfCookie.toString());
 
         // 응답 바디 없이 204 No Content
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
-//        return ApiResponse.onSuccess(tokens);
+
+//        return ApiResponse.onSuccess(tokens); // 테스트용
 
 //        return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -34,8 +34,8 @@ public class AuthRestController {
             description = "JWT 인증된 멤버가 로그아웃하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
-    public ApiResponse<Void> logout(@AuthenticationPrincipal MemberDetails memberDetails) {
-        memberCommandService.logout(memberDetails.getMember().getId());
+    public ApiResponse<Void> logout(@AuthenticationPrincipal MemberDetails memberDetails, HttpServletResponse response) {
+        memberCommandService.logout(response, memberDetails.getMember().getId());
         return ApiResponse.onSuccess(null);
     }
 

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -15,6 +15,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.web.csrf.CsrfToken;
+import org.springframework.security.web.csrf.CsrfTokenRepository;
 import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,7 +32,7 @@ public class AuthRestController {
     private final JwtTokenProvider jwtTokenProvider;
 
     @PostMapping("/logout")
-    @Operation(summary = "회원 로그아웃 API - JWT 인증 필요",
+    @Operation(summary = "회원 로그아웃 API - JWT AccessToken 인증 필요, CSRF 인증은 요구되지 않습니다.",
             description = "JWT 인증된 멤버가 로그아웃하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
@@ -40,23 +42,39 @@ public class AuthRestController {
     }
 
     @PostMapping("/reissue")
-    @Operation(summary = "토큰 재발급 API",
-            description = "RefreshToken으로 AccessToken을 재발급받는 API입니다."
+    @Operation(summary = "토큰 재발급 API - JWT RefreshToken 인증 필요, CSRF 인증은 요구되지 않습니다.",
+            description = "RefreshToken으로 AccessToken과 CSRF 토큰을 재발급받는 API입니다. AccessToken은 HttpOnly 쿠키로, CSRF 토큰은 일반 쿠키로 내려줍니다."
     )
 //    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request) {
 //        String refreshToken = JwtTokenProvider.resolveToken(request); // Authorization 헤더에서 Bearer 토큰을 추출
     public void reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
-        String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
+//    public ApiResponse<AuthResponseDTO.ReissueTokenResponseDTO> reissueAccessToken(HttpServletRequest request, HttpServletResponse response) {
+
+            String refreshToken = jwtTokenProvider.resolveRefreshToken(request);
         if (!StringUtils.hasText(refreshToken) || !jwtTokenProvider.isRefreshToken(refreshToken)) { // refreshToken == null은 !StringUtils.hasText(refreshToken)로 체크 가능
             throw new MemberHandler(ErrorStatus.INVALID_JWT_REFRESH_TOKEN); // TOKEN4002
         }
 
         AuthResponseDTO.ReissueTokenResponseDTO tokens = authCommandService.reissue(refreshToken);
 
+        // 어세스 토큰 재발급
         addCookie(response, "accessToken", tokens.getAccessToken(), true, 60 * 60 * 4); // 4시간
+
+        // csrf 토큰 재발급
+        CsrfToken csrfToken = authCommandService.generateCsrfToken(request, response);
+        ResponseCookie csrfCookie = ResponseCookie.from("XSRF-TOKEN", csrfToken.getToken())
+                .httpOnly(false)    // JS에서 읽을 수 있어야 함
+                .secure(true)
+                .path("/")
+                .domain("dnbn.site")
+                .maxAge(60 * 60)    // 1시간, 필요 시 조절
+                .sameSite("Lax")
+                .build();
+        response.addHeader("Set-Cookie", csrfCookie.toString());
 
         // 응답 바디 없이 204 No Content
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);
+//        return ApiResponse.onSuccess(tokens);
 
 //        return ApiResponse.onSuccess(response);
     }

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -20,7 +20,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/auth")
+@RequestMapping("api/auth")
 public class AuthRestController {
 
     private final MemberCommandService memberCommandService;

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -49,7 +49,7 @@ public class MemberRestController {
     }
 
     @GetMapping("/info")
-    @Operation(summary = "회원 정보 조회 API - JWT AccessToken + CSRF 토큰 인증 필요",
+    @Operation(summary = "회원 정보 조회 API - JWT AccessToken 인증 필요",
             description = "JWT 인증된 멤버가 자신의 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") } // ‘내 정보 조회’는 로그인한 사용자만이 접근할 수 있는 API여야 함 --> Swagger 어노테이션인 @Operation 어노테이션에 security 필드를 추가해서 token이 요청 필수값임을 명시
     )

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -22,7 +22,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/member")
+@RequestMapping("api/member")
 public class MemberRestController {
 
     private final MemberQueryService memberQueryService;

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -33,7 +33,7 @@ public class MemberRestController {
             consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
     )
     @Operation(
-            summary = "회원 초기 정보 등록 (온보딩) API - JWT 인증 필요",
+            summary = "회원 초기 정보 등록 (온보딩) API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 멤버가 닉네임, 프로필 이미지, 선호 지역을 등록하는 API입니다.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
@@ -49,7 +49,7 @@ public class MemberRestController {
     }
 
     @GetMapping("/info")
-    @Operation(summary = "회원 정보 조회 API - JWT 인증 필요",
+    @Operation(summary = "회원 정보 조회 API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 멤버가 자신의 정보를 조회하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") } // ‘내 정보 조회’는 로그인한 사용자만이 접근할 수 있는 API여야 함 --> Swagger 어노테이션인 @Operation 어노테이션에 security 필드를 추가해서 token이 요청 필수값임을 명시
     )
@@ -64,7 +64,7 @@ public class MemberRestController {
     }
 
     @DeleteMapping
-    @Operation(summary = "회원 탈퇴 API - JWT 인증 필요",
+    @Operation(summary = "회원 탈퇴 API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 멤버가 자신의 계정을 탈퇴(삭제)하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
@@ -74,7 +74,7 @@ public class MemberRestController {
     }
 
     @PatchMapping("/nickname")
-    @Operation(summary = "회원 닉네임 변경 API - JWT 인증 필요",
+    @Operation(summary = "회원 닉네임 변경 API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 멤버가 자신의 닉네임을 변경하는 API입니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )
@@ -90,7 +90,7 @@ public class MemberRestController {
 
     @PatchMapping("/regions")
     @Operation(
-            summary = "관심 동네 변경 API - JWT 인증 필요",
+            summary = "관심 동네 변경 API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 멤버가 자신의 관심 동네를 수정하는 API입니다.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
@@ -108,7 +108,7 @@ public class MemberRestController {
             consumes = MediaType.MULTIPART_FORM_DATA_VALUE
     )
     @Operation(
-            summary = "프로필 이미지 변경 API - JWT 인증 필요",
+            summary = "프로필 이미지 변경 API - JWT AccessToken + CSRF 토큰 인증 필요",
             description = "JWT 인증된 사용자가 프로필 이미지를 변경합니다.",
             security = { @SecurityRequirement(name = "JWT TOKEN") }
     )

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: https://api.dnbn.site/login/oauth2/code/kakao
+            redirect-uri: ${KAKAO_REDIRECT_URL}
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao
@@ -37,7 +37,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_SECRET}
-            redirect-uri: https://api.dnbn.site/login/oauth2/code/naver
+            redirect-uri: ${NAVER_REDIRECT_URL}
             authorization-grant-type: authorization_code
             scope:
             client-name: Naver
@@ -45,7 +45,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_SECRET}
-            redirect-uri: https://api.dnbn.site/login/oauth2/code/kakao
+            redirect-uri: ${GOOGLE_REDIRECT_URL}
             authorization-grant-type: authorization_code
             scope:
               - openid

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -45,7 +45,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_SECRET}
-            redirect-uri: https://api.dnbn.site/login/oauth2/code/google
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
               - openid

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -29,7 +29,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao
@@ -37,7 +37,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${NAVER_CLIENT_ID}
             client-secret: ${NAVER_SECRET}
-            redirect-uri: ${NAVER_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/naver
             authorization-grant-type: authorization_code
             scope:
             client-name: Naver
@@ -45,7 +45,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${GOOGLE_CLIENT_ID}
             client-secret: ${GOOGLE_SECRET}
-            redirect-uri: ${GOOGLE_REDIRECT_URL}
+            redirect-uri: https://api.dnbn.site/login/oauth2/code/google
             authorization-grant-type: authorization_code
             scope:
               - openid
@@ -79,6 +79,7 @@ spring:
       #   - 이 경우 파일 크기 초과 등 예외가 ExceptionHandler까지 도달하지 않고, 더 앞단(서블릿 컨테이너 등)에서 처리됨
       resolve-lazily: false
 server:
+  forward-headers-strategy: framework
   tomcat:
     max-swallow-size: 200MB
 jwt:


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 도메인 주소로 소셜 로그인 구현 완료함
- [x] xss 취약점 방지 위해 소셜 로그인 쿠키로 내려주기 구현
- [x] 토큰 재발급도 쿠키로 내려주기
- [x] 로그아웃 시 쿠키 삭제
- [x] csrf 취약점 발견 후 방지 위해 Security Config 코드 수정
- [x] 프론트로부터 전달받은 브릿지 페이지 url로 성공/실패 핸들러의 리다이렉트 코드 수정(/oauth-redirect)
- [x] 토큰 재발급에서 csrf토큰도 같이 재발급 되도록

## 📸 스크린샷 (선택)
1. 스웨거 테스트 위해서 임시로 application.yaml에 redirect-uri: http://localhost:8080/login/oauth2/code/kakao로 수정
<img width="619" height="506" alt="image" src="https://github.com/user-attachments/assets/4468e8d9-855d-49cc-a0e3-4a8beb704e23" />

2. 임시로 localhost:8080으로 카카오 소셜 로그인 진행해봄
<img width="825" height="358" alt="image" src="https://github.com/user-attachments/assets/d2e388a7-c5a1-4718-8d74-2e999041d644" />

3. 개발자 도구(F12) -> Application -> Cookies에서 csrf토큰 확인할 수 있음
<img width="794" height="475" alt="image" src="https://github.com/user-attachments/assets/a1736272-e9c1-477b-a023-7f2830643d98" />

4. 스웨거 Authorizaion에 2번에서 받은 JWT토큰 넣고

5. 회원 정보 조회 API해봄(여기에 3번의 쿠키로 받은 토큰 입력하고 해야 함)
<img width="400" height="521" alt="image" src="https://github.com/user-attachments/assets/c42b9ccd-f048-49d0-921a-aa63a71fcb71" />

잘 되는 것 확인함
<img width="334" height="284" alt="image" src="https://github.com/user-attachments/assets/1440c852-483c-476f-848b-69cd7aab2dd6" />
---
GET은 CSRF값 없어도 요청 가능
<img width="487" height="800" alt="image" src="https://github.com/user-attachments/assets/78475eef-7a49-48f1-ae05-423321713d16" />
---
예를 들어 CSRF토큰 값 없이 요청하거나 잘못된 값을 넣으면 아래처럼 보이게 해뒀어요
<img width="488" height="276" alt="image" src="https://github.com/user-attachments/assets/b36d4d6f-8678-4209-854e-4d1916c6f24e" />

## 💬 기타(공유사항 to 리뷰어)
아직 머지하지 말아주세요