### PR TITLE
✨ [Feat] 챌린지 좋아요 1등 게시물 조회

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -38,6 +38,9 @@ public enum ErrorStatus implements BaseErrorCode {
     ARTICLE_PHOTO_IMAGE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "ARTICLEPHOTO4004", "이미지 파일 크기가 너무 큽니다. (최대 10MB)"),
     ARTICLE_PHOTO_S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "ARTICLEPHOTO5001", "이미지 업로드에 실패했습니다. 잠시 후 다시 시도해 주세요."),
 
+    // article & challenge
+    ARTICLE_CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND,"ARTICLECHALLENGE4001", "해당하는 해시태그를 포함한 챌린지 게시물을 찾을 수 없습니다."),
+
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
 

--- a/src/main/java/DNBN/spring/converter/ArticleConverter.java
+++ b/src/main/java/DNBN/spring/converter/ArticleConverter.java
@@ -33,7 +33,6 @@ public class ArticleConverter {
         return PostResponseDTO.PostPreViewDTO.builder()
                 .articleId(article.getArticleId())
                 .memberId(article.getMember().getId())
-                .categoryId(article.getCategory().getCategoryId())
                 .placeId(article.getPlace().getPlaceId())
                 .regionId(article.getRegion().getId())
                 .title(article.getTitle())

--- a/src/main/java/DNBN/spring/converter/ChallengeConverter.java
+++ b/src/main/java/DNBN/spring/converter/ChallengeConverter.java
@@ -1,7 +1,9 @@
 package DNBN.spring.converter;
 
+import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Challenge;
 import DNBN.spring.web.dto.response.ChallengeResponseDTO;
+import DNBN.spring.web.dto.response.PostResponseDTO;
 
 public class ChallengeConverter {
     public static ChallengeResponseDTO.ChallengeDetailDTO challengeDetailDTO(Challenge challenge) {

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -52,6 +52,8 @@ public class Article extends BaseEntity {
   private Long spamCount = 0L;
 
   private LocalDateTime deletedAt;
+
+  private String hashtag;
   
   public void increaseLikeCount() {
     this.likesCount++;

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -20,6 +20,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
 
-    Optional<Article> findTopByContentContainingOrderByLikesCountDesc(String keyword);
+    Optional<Article> findTopByContentContainingOrderByLikesCountDescCreatedAtAsc(String keyword);
 }
 

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -20,6 +20,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
 
-    Optional<Article> findTopByContentContainingOrderByLikesCountDescCreatedAtAsc(String keyword);
+    Optional<Article> findTopByHashtagOrderByLikesCountDescCreatedAtAsc(String keyword);
 }
 

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.util.Optional;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findAllByMember(Member member);
@@ -18,5 +19,7 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findAllByRegion(Region region);
 
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
+
+    Optional<Article> findTopByOrderByLikesCountDesc();
 }
 

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -20,6 +20,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
 
-    Optional<Article> findTopByOrderByLikesCountDesc();
+    Optional<Article> findTopByContentContainingOrderByLikesCountDesc(String keyword);
 }
 

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
@@ -1,10 +1,12 @@
 package DNBN.spring.service.ArticleService;
 
 import DNBN.spring.domain.Article;
+import DNBN.spring.web.dto.response.PostResponseDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface ArticleQueryService {
     Page<Article> getArticleListByRegion(Long memberId, Integer page);
+    PostResponseDTO.PostPreViewDTO getTopChallengeArticle();
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -38,7 +38,8 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
 
     @Override
     public PostResponseDTO.PostPreViewDTO getTopChallengeArticle() {
-        Article topArticle = articleRepository.findTopByOrderByLikesCountDesc()
+        String requiredTag = "8월 챌린지";
+        Article topArticle = articleRepository.findTopByContentContainingOrderByLikesCountDesc(requiredTag)
                 .orElseThrow(() -> new IllegalArgumentException("<UNK> <UNK> <UNK> <UNK>."));
         return ArticleConverter.articlePreViewDTO(topArticle);
     }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -39,7 +39,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     @Override
     public PostResponseDTO.PostPreViewDTO getTopChallengeArticle() {
         String requiredTag = "8월 챌린지";
-        Article topArticle = articleRepository.findTopByContentContainingOrderByLikesCountDescCreatedAtAsc(requiredTag)
+        Article topArticle = articleRepository.findTopByHashtagOrderByLikesCountDescCreatedAtAsc(requiredTag)
                 .orElseThrow(() -> new IllegalArgumentException("<UNK> <UNK> <UNK> <UNK>."));
         return ArticleConverter.articlePreViewDTO(topArticle);
     }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -39,7 +39,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     @Override
     public PostResponseDTO.PostPreViewDTO getTopChallengeArticle() {
         String requiredTag = "8월 챌린지";
-        Article topArticle = articleRepository.findTopByContentContainingOrderByLikesCountDesc(requiredTag)
+        Article topArticle = articleRepository.findTopByContentContainingOrderByLikesCountDescCreatedAtAsc(requiredTag)
                 .orElseThrow(() -> new IllegalArgumentException("<UNK> <UNK> <UNK> <UNK>."));
         return ArticleConverter.articlePreViewDTO(topArticle);
     }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -1,5 +1,7 @@
 package DNBN.spring.service.ArticleService;
 
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
 import DNBN.spring.converter.ArticleConverter;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Region;
@@ -40,7 +42,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     public PostResponseDTO.PostPreViewDTO getTopChallengeArticle() {
         String requiredTag = "8월 챌린지";
         Article topArticle = articleRepository.findTopByHashtagOrderByLikesCountDescCreatedAtAsc(requiredTag)
-                .orElseThrow(() -> new IllegalArgumentException("<UNK> <UNK> <UNK> <UNK>."));
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_CHALLENGE_NOT_FOUND));
         return ArticleConverter.articlePreViewDTO(topArticle);
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -1,10 +1,12 @@
 package DNBN.spring.service.ArticleService;
 
+import DNBN.spring.converter.ArticleConverter;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Region;
 import DNBN.spring.repository.ArticleRepository.ArticleRepository;
 import DNBN.spring.repository.LikeRegionRepository.LikeRegionRepository;
 import DNBN.spring.repository.RegionRepository.RegionRepository;
+import DNBN.spring.web.dto.response.PostResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -32,6 +34,13 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
 
         Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         return articleRepository.findAllByRegion_IdIn(regionIds, pageable);
+    }
+
+    @Override
+    public PostResponseDTO.PostPreViewDTO getTopChallengeArticle() {
+        Article topArticle = articleRepository.findTopByOrderByLikesCountDesc()
+                .orElseThrow(() -> new IllegalArgumentException("<UNK> <UNK> <UNK> <UNK>."));
+        return ArticleConverter.articlePreViewDTO(topArticle);
     }
 }
 

--- a/src/main/java/DNBN/spring/web/controller/HomeController.java
+++ b/src/main/java/DNBN/spring/web/controller/HomeController.java
@@ -55,4 +55,13 @@ public class HomeController {
     public ApiResponse<ChallengeResponseDTO.ChallengeDetailDTO> getChallengeDetail(@PathVariable Long challengeId) {
         return ApiResponse.onSuccess(challengeQueryService.getChallengeDetail(challengeId));
     }
+
+    @GetMapping("/challenge/top-article")
+    @Operation(
+            summary = "챌린지 좋아요 1등 게시물 조회 API - JWT 인증 필요",
+            description = "챌린지 게시물 중 좋아요 1등 게시물을 조회하는 api입니다."
+    )
+    public ApiResponse<PostResponseDTO.PostPreViewDTO> getTopArticle() {
+        return ApiResponse.onSuccess(articleQueryService.getTopChallengeArticle());
+    }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
챌린지 해시태그를 포함한 게시물 중 좋아요가 1등인 게시물을 반환
좋아요 개수가 동일하면 먼저 작성된 게시물 반환

## 🛠️ 작업 상세 내용
- jpa 사용
- converter, repository, service 구현

## 📸 스크린샷
- 챌린지 게시물이 존재하지 않을 때
<img width="828" height="185" alt="image" src="https://github.com/user-attachments/assets/9bcb1012-d9b0-47a3-b1e1-c80f298f2beb" />
- 200 성공
<img width="810" height="402" alt="image" src="https://github.com/user-attachments/assets/c4f3521f-e97f-43b4-805c-9dbfb2dc617b" />


## 💬 기타(공유사항 to 리뷰어)
브랜치 삭제 금지
