### PR TITLE
✨ [Feat] 카테고리에 작성한 게시물 조회

### DIFF
--- a/src/main/java/DNBN/spring/converter/ArticleConverter.java
+++ b/src/main/java/DNBN/spring/converter/ArticleConverter.java
@@ -57,4 +57,30 @@ public class ArticleConverter {
                 .postList(articleDTOList)
                 .build();
     }
+
+    public static ArticleResponseDTO.ArticlePreviewDTO toPreviewDTO(
+            Article article, String imageUrl, Long commentCount) {
+        return ArticleResponseDTO.ArticlePreviewDTO.builder()
+                .articleId(article.getArticleId())
+                .pinCategory(article.getPlace().getPinCategory().name())
+                .imageUrl(imageUrl)
+                .title(article.getTitle())
+                .likes(article.getLikesCount())
+                .spam(article.getSpamCount())
+                .comments(commentCount)
+                .build();
+    }
+
+    public static ArticleResponseDTO.ArticleListDTO toListDTO(
+            List<ArticleResponseDTO.ArticlePreviewDTO> previews, Long limit, boolean hasNext) {
+
+        Long nextCursor = previews.isEmpty() ? null : previews.get(previews.size() - 1).getArticleId();
+
+        return ArticleResponseDTO.ArticleListDTO.builder()
+                .articles(previews)
+                .cursor(nextCursor)
+                .limit(limit)
+                .hasNext(hasNext)
+                .build();
+    }
 }

--- a/src/main/java/DNBN/spring/converter/ArticleConverter.java
+++ b/src/main/java/DNBN/spring/converter/ArticleConverter.java
@@ -59,7 +59,7 @@ public class ArticleConverter {
     }
 
     public static ArticleResponseDTO.ArticlePreviewDTO toPreviewDTO(
-            Article article, String imageUrl, Long commentCount) {
+            Article article, String imageUrl) {
         return ArticleResponseDTO.ArticlePreviewDTO.builder()
                 .articleId(article.getArticleId())
                 .pinCategory(article.getPlace().getPinCategory().name())
@@ -67,7 +67,7 @@ public class ArticleConverter {
                 .title(article.getTitle())
                 .likes(article.getLikesCount())
                 .spam(article.getSpamCount())
-                .comments(commentCount)
+                .comments(article.getCommentCount())
                 .build();
     }
 

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -51,6 +51,9 @@ public class Article extends BaseEntity {
   @Column(nullable = false, columnDefinition = "BIGINT DEFAULT 0")
   private Long spamCount = 0L;
 
+  @Column(name = "comment_count", nullable = false, columnDefinition = "BIGINT DEFAULT 0")
+  private Long commentCount;
+
   private LocalDateTime deletedAt;
 
   @Column(nullable = false)

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
@@ -1,0 +1,9 @@
+package DNBN.spring.repository.ArticleRepository;
+
+import DNBN.spring.domain.Article;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<Article> findArticlesByCategoryWithCursor(Long categoryId, Long cursor, Long limit);
+}

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
@@ -1,0 +1,37 @@
+package DNBN.spring.repository.ArticleRepository;
+
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.QArticle;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<Article> findArticlesByCategoryWithCursor(Long categoryId, Long cursor, Long limit) {
+        QArticle article = QArticle.article;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(article.category.categoryId.eq(categoryId));
+        builder.and(article.deletedAt.isNull());
+
+        if (cursor != null) {
+            builder.and(article.articleId.lt(cursor));
+        }
+
+        return queryFactory
+                .selectFrom(article)
+                .where(builder)
+                .orderBy(article.articleId.desc())
+                .limit(limit + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
@@ -31,7 +31,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                 .selectFrom(article)
                 .where(builder)
                 .orderBy(article.articleId.desc())
-                .limit(limit + 1)
+                .limit(limit)
                 .fetch();
     }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
@@ -1,10 +1,12 @@
 package DNBN.spring.service.ArticleService;
 
 import DNBN.spring.domain.Article;
+import DNBN.spring.web.dto.ArticleResponseDTO;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
 
 public interface ArticleQueryService {
     Page<Article> getArticleListByRegion(Long memberId, Integer page);
+    ArticleResponseDTO.ArticleListDTO getArticlesByCategory(Long categoryId, Long memberId, Long cursor, Long limit);
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -1,10 +1,18 @@
 package DNBN.spring.service.ArticleService;
 
-import DNBN.spring.domain.Article;
-import DNBN.spring.domain.Region;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.CategoryHandler;
+import DNBN.spring.aws.s3.AmazonS3Manager;
+import DNBN.spring.converter.ArticleConverter;
+import DNBN.spring.domain.*;
+import DNBN.spring.repository.ArticlePhotoRepository.ArticlePhotoRepository;
 import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.repository.ArticleRepository.ArticleRepositoryCustom;
+import DNBN.spring.repository.CategoryRepository.CategoryRepository;
+import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.repository.LikeRegionRepository.LikeRegionRepository;
 import DNBN.spring.repository.RegionRepository.RegionRepository;
+import DNBN.spring.web.dto.ArticleResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -21,6 +29,11 @@ import java.util.List;
 public class ArticleQueryServiceImpl implements ArticleQueryService {
     private final ArticleRepository articleRepository;
     private final LikeRegionRepository likeRegionRepository;
+    private final CategoryRepository categoryRepository;
+    private final CommentRepository commentRepository;
+    private final ArticlePhotoRepository articlePhotoRepository;
+    private final ArticleRepositoryCustom articleRepositoryCustom;
+    private final AmazonS3Manager amazonS3Manager;
 
     @Override
     public Page<Article> getArticleListByRegion(Long memberId, Integer page) {
@@ -33,5 +46,33 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
         Pageable pageable = PageRequest.of(page - 1, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         return articleRepository.findAllByRegion_IdIn(regionIds, pageable);
     }
-}
 
+    @Override
+    public ArticleResponseDTO.ArticleListDTO getArticlesByCategory(Long categoryId, Long memberId, Long cursor, Long limit) {
+        // 1. 카테고리 소유 확인
+        Category category = categoryRepository.findByCategoryIdAndMemberAndDeletedAtIsNull(categoryId, Member.builder().id(memberId).build())
+                .orElseThrow(() -> new CategoryHandler(ErrorStatus._FORBIDDEN));
+
+        // 2. 게시물 조회 (limit + 1 조회로 hasNext 판별)
+        List<Article> articles = articleRepositoryCustom.findArticlesByCategoryWithCursor(categoryId, cursor, limit + 1);
+
+        boolean hasNext = articles.size() > limit;
+        if (hasNext) articles.remove(articles.size() - 1);
+
+        // 3. 변환
+        List<ArticleResponseDTO.ArticlePreviewDTO> previews = articles.stream()
+                .map(article -> {
+                    String mainImage = articlePhotoRepository.findAllByArticle(article).stream()
+                            .filter(ArticlePhoto::getIsMain)
+                            .findFirst()
+                            .map(photo -> photo.getFileKey())
+                            .orElse("기본 이미지 URL");
+
+                    long commentCount = commentRepository.findAllByArticle(article).size();
+
+                    return ArticleConverter.toPreviewDTO(article, mainImage, commentCount);
+                }).toList();
+
+        return ArticleConverter.toListDTO(previews, limit, hasNext);
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/CategoryController.java
+++ b/src/main/java/DNBN/spring/web/controller/CategoryController.java
@@ -6,8 +6,10 @@ import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.service.ArticleService.ArticleQueryService;
 import DNBN.spring.service.CategoryService.CategoryQueryService;
 import DNBN.spring.service.CategoryService.CategoryService;
+import DNBN.spring.web.dto.ArticleResponseDTO;
 import DNBN.spring.web.dto.CategoryRequestDTO;
 import DNBN.spring.web.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
@@ -31,6 +33,7 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final ArticleQueryService articleQueryService;
 
     @Operation(summary = "내 카테고리 목록 조회", description = "로그인한 사용자의 카테고리 목록을 반환합니다.")
     @GetMapping("/my")
@@ -82,5 +85,18 @@ public class CategoryController {
         Member member = memberRepository.findBySocialId(socialId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         return member.getId();
+    }
+
+    @Operation(summary = "카테고리에 작성된 게시물 목록 조회", description = "해당 카테고리에 작성된 게시물들을 반환합니다.")
+    @GetMapping("/{categoryId}/articles")
+    public ResponseEntity<ApiResponse<ArticleResponseDTO.ArticleListDTO>> getArticlesByCategory(
+            @PathVariable Long categoryId,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "20") Long limit,
+            HttpServletRequest request) {
+
+        Long memberId = extractMemberIdFromToken(request);
+        ArticleResponseDTO.ArticleListDTO result = articleQueryService.getArticlesByCategory(categoryId, memberId, cursor, limit);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 }

--- a/src/main/java/DNBN/spring/web/controller/CategoryController.java
+++ b/src/main/java/DNBN/spring/web/controller/CategoryController.java
@@ -13,6 +13,7 @@ import DNBN.spring.web.dto.ArticleResponseDTO;
 import DNBN.spring.web.dto.CategoryRequestDTO;
 import DNBN.spring.web.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -91,8 +92,13 @@ public class CategoryController {
     @GetMapping("/{categoryId}/articles")
     public ResponseEntity<ApiResponse<ArticleResponseDTO.ArticleListDTO>> getArticlesByCategory(
             @PathVariable Long categoryId,
+
+            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 articleId (default: null) -> 응답받은 cursor 값 넣어주면 됨", example = "0")
             @RequestParam(required = false) Long cursor,
+
+            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
             @RequestParam(defaultValue = "20") Long limit,
+
             HttpServletRequest request) {
 
         Long memberId = extractMemberIdFromToken(request);

--- a/src/main/java/DNBN/spring/web/controller/CategoryController.java
+++ b/src/main/java/DNBN/spring/web/controller/CategoryController.java
@@ -14,6 +14,7 @@ import DNBN.spring.web.dto.CategoryRequestDTO;
 import DNBN.spring.web.dto.CategoryResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -93,10 +94,19 @@ public class CategoryController {
     public ResponseEntity<ApiResponse<ArticleResponseDTO.ArticleListDTO>> getArticlesByCategory(
             @PathVariable Long categoryId,
 
-            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 articleId (default: null) -> 응답받은 cursor 값 넣어주면 됨", example = "0")
+            @Parameter(
+                    name        = "cursor",
+                    description = "다음 페이지 기준이 되는 커서 articleId (default: null)",
+                    schema      = @Schema(type="integer", format="int64", defaultValue = "null")
+            )
             @RequestParam(required = false) Long cursor,
 
-            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
+            @Parameter(
+                    name        = "limit",
+                    description = "최대 응답 개수 (default: 20)",
+                    schema      = @Schema(type="integer", format="int64", defaultValue = "20"),
+                    example     = "20"
+            )
             @RequestParam(defaultValue = "20") Long limit,
 
             HttpServletRequest request) {

--- a/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
@@ -23,5 +23,27 @@ public class ArticleResponseDTO {
     private Long spamCount;
     private String createdAt;
     private String updatedAt;
+
+    @Builder
+    @Getter
+    public static class ArticlePreviewDTO {
+        private Long articleId;
+        private String pinCategory;
+        private String imageUrl;
+        private String title;
+        private Long likes;
+        private Long spam;
+        private Long comments;
+    }
+
+    @Builder
+    @Getter
+    public static class ArticleListDTO {
+        private List<ArticlePreviewDTO> articles;
+        private Long cursor;
+        private Long limit;
+        private boolean hasNext;
+    }
+
 }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
- GET /api/categories/{categoryId}/articles API 구현
- 사용자가 본인의 카테고리에 작성한 게시글 조회

## 🛠️ 작업 상세 내용
- [x] JWT 인증 후 사용자 소유 카테고리 권한 검증 포함
- [x] Article 엔티티에 DB comment_count 컬럼을 매핑하는 private Long commentCount 필드 추가
- [x] Cursor 기반 페이징 (최신순)
- [x] 댓글 수, 좋아요/스팸 수, 대표 이미지 모두 함께 응답

## 📸 스크린샷 (선택)
<img width="1136" height="343" alt="스크린샷 2025-07-29 오후 5 47 22" src="https://github.com/user-attachments/assets/4d5c62d2-1b54-4397-89db-887afc58e28b" />

<img width="1203" height="145" alt="스크린샷 2025-07-29 오후 5 47 34" src="https://github.com/user-attachments/assets/b88f8aa3-279f-4776-841e-1c73397afd21" />

## 💬 기타(공유사항 to 리뷰어)

https://api.dnbn.site/oauth2/authorization/kakao
https://api.dnbn.site/oauth2/authorization/naver
https://api.dnbn.site/oauth2/authorization/google

- 본인의 카테고리 아이디  제외 입력 시 4003 "금지된 요청입니다." 에러 발생
