### PR TITLE
♻️ [Refactor] 카테고리에 저장한 장소 조회 api path 수정 및 페이징 흐름 변경

### DIFF
--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepositoryImpl.java
@@ -23,12 +23,12 @@ public class SavePlaceRepositoryImpl implements SavePlaceRepositoryCustom {
         builder.and(savePlace.category.categoryId.eq(categoryId));
 
         if (cursor != null) {
-            builder.and(savePlace.id.gt(cursor));
+            builder.and(savePlace.id.lt(cursor));
         }
 
         return jpaQueryFactory.selectFrom(savePlace)
                 .where(builder)
-                .orderBy(savePlace.id.asc())
+                .orderBy(savePlace.id.desc())
                 .limit(limit)
                 .fetch();
     }

--- a/src/main/java/DNBN/spring/web/controller/CategoryController.java
+++ b/src/main/java/DNBN/spring/web/controller/CategoryController.java
@@ -8,9 +8,13 @@ import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.service.CategoryService.CategoryQueryService;
 import DNBN.spring.service.CategoryService.CategoryService;
+import DNBN.spring.service.PlaceService.PlaceQueryService;
 import DNBN.spring.web.dto.CategoryRequestDTO;
 import DNBN.spring.web.dto.CategoryResponseDTO;
+import DNBN.spring.web.dto.PlaceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -31,6 +35,7 @@ public class CategoryController {
     private final CategoryQueryService categoryQueryService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
+    private final PlaceQueryService placeQueryService;
 
     @Operation(summary = "내 카테고리 목록 조회", description = "로그인한 사용자의 카테고리 목록을 반환합니다.")
     @GetMapping("/my")
@@ -70,6 +75,34 @@ public class CategoryController {
         Long memberId = extractMemberIdFromToken(request);
         categoryService.delete(memberId, categoryId);
         return ResponseEntity.ok(ApiResponse.onSuccess(null));
+    }
+
+    @Operation(summary     = "카테고리에 저장된 장소 목록 조회", description = "해당 카테고리에 저장된 장소들을 커서 기반 페이징으로 반환합니다.")
+    @GetMapping("/{categoryId}/places")
+    public ResponseEntity<ApiResponse<PlaceResponseDTO.SavedPlaceListDTO>> getPlacesByCategory(
+            @PathVariable Long categoryId,
+
+            @Parameter(
+                    name        = "cursor",
+                    description = "다음 페이지 요청 시 기준이 되는 save_place PK (default: null)",
+                    schema      = @Schema(type="integer", format="int64", defaultValue="null")
+            )
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(
+                    name        = "limit",
+                    description = "최대 응답 개수 (default: 20)",
+                    schema      = @Schema(type="integer", format="int64", defaultValue="20"),
+                    example     = "20"
+            )
+            @RequestParam(defaultValue = "20") Long limit,
+
+            HttpServletRequest request
+    ) {
+        Long memberId = extractMemberIdFromToken(request);
+        PlaceResponseDTO.SavedPlaceListDTO result =
+                placeQueryService.getSavedPlaces(categoryId, memberId, cursor, limit);
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
     private Long extractMemberIdFromToken(HttpServletRequest request) {

--- a/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
@@ -7,11 +7,9 @@ import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.service.PlaceService.PlaceCommandService;
-import DNBN.spring.service.PlaceService.PlaceQueryService;
 import DNBN.spring.web.dto.PlaceRequestDTO;
 import DNBN.spring.web.dto.PlaceResponseDTO;
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
@@ -28,7 +26,6 @@ public class PlaceRestController {
     private final PlaceCommandService placeCommandService;
     private final JwtTokenProvider jwtTokenProvider;
     private final MemberRepository memberRepository;
-    private final PlaceQueryService placeQueryService;
 
     @Operation(summary = "장소 카테고리에 저장", description = "장소를 사용자의 카테고리에 저장합니다.")
     @PostMapping("/{placeId}/categories")
@@ -39,24 +36,6 @@ public class PlaceRestController {
 
         Long memberId = extractMemberIdFromToken(request);
         PlaceResponseDTO.SavePlaceResultDTO response = placeCommandService.savePlaceToCategory(memberId, placeId, dto);
-        return ResponseEntity.ok(ApiResponse.onSuccess(response));
-    }
-
-    @Operation(summary = "카테고리에 저장된 장소 목록 조회", description = "해당 카테고리에 저장된 장소들을 조회합니다.")
-    @GetMapping("/categories/{categoryId}/places")
-    public ResponseEntity<ApiResponse<PlaceResponseDTO.SavedPlaceListDTO>> getSavedPlacesByCategory(
-            @PathVariable Long categoryId,
-
-            @Parameter(name = "cursor", description = "다음 페이지 요청 시 기준이 되는 커서 ID (save_place PK) (default: null) -> 응답받은 cursor 값 넣어주면 됨", example = "0")
-            @RequestParam(required = false) Long cursor,
-
-            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
-            @RequestParam(defaultValue = "20") Long limit,
-
-            HttpServletRequest request
-    ) {
-        Long memberId = extractMemberIdFromToken(request);
-        PlaceResponseDTO.SavedPlaceListDTO response = placeQueryService.getSavedPlaces(categoryId, memberId, cursor, limit);
         return ResponseEntity.ok(ApiResponse.onSuccess(response));
     }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> /api/places/categories/{categoryId}/places -> /api/categories/{categoryId}/places 로 수정

## 🛠️ 작업 상세 내용
- [x] SavePlaceRepositoryImpl 및 PlaceQueryServiceImpl 에서 orderBy(savePlace.id.desc()) 로 가장 최근에 저장된 장소가 먼저 조회되도록 변경

## 📸 스크린샷 (선택)
<img width="1047" height="328" alt="스크린샷 2025-07-29 오후 8 43 15" src="https://github.com/user-attachments/assets/18624d37-331d-4df8-98af-246c62986ea2" />
<img width="1036" height="199" alt="스크린샷 2025-07-29 오후 8 43 21" src="https://github.com/user-attachments/assets/8b0dee50-d5bb-42e4-9475-ce64d31e4b08" />

<img width="1065" height="159" alt="스크린샷 2025-07-29 오후 8 43 29" src="https://github.com/user-attachments/assets/91a1f7ce-9d94-4bb9-bd73-547543012ade" />

## 💬 기타(공유사항 to 리뷰어)

https://api.dnbn.site/oauth2/authorization/kakao
https://api.dnbn.site/oauth2/authorization/naver
https://api.dnbn.site/oauth2/authorization/google

1. 가장 최근에 저장한 장소가 먼저 반환됨
2. 본인의 카테고리 id 제외 입력 시 4003 "금지된 요청입니다" 에러 발생