### PR TITLE
♻️ [Refactor] 게시물 생성 중복 코드 및 AOP 분리

### DIFF
--- a/src/main/java/DNBN/spring/aop/ArticleCreateValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleCreateValidationAspect.java
@@ -1,0 +1,80 @@
+package DNBN.spring.aop;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.ArticlePhotoHandler;
+import DNBN.spring.web.dto.ArticleRequestDTO;
+import DNBN.spring.web.dto.ArticleWithLocationRequestDTO;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Aspect
+@Component
+public class ArticleCreateValidationAspect {
+    private static final int TITLE_MIN_LENGTH = 2;
+    private static final int TITLE_MAX_LENGTH = 100;
+    private static final int CONTENT_MIN_LENGTH = 10;
+    private static final int CONTENT_MAX_LENGTH = 5000;
+    private static final int MAX_IMAGE_COUNT = 10;
+    private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
+
+    @Before("execution(* DNBN.spring.service.ArticleService.ArticleCommandServiceImpl.createArticle(..))")
+    public void validateCreateArticle(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        Object dto = args[1];
+        MultipartFile mainImage = (MultipartFile) args[2];
+        List<MultipartFile> imageFiles = (List<MultipartFile>) args[3];
+
+        String title = null;
+        String content = null;
+        if (dto instanceof ArticleRequestDTO request) {
+            title = request.title();
+            content = request.content();
+        } else if (dto instanceof ArticleWithLocationRequestDTO request) {
+            title = request.title();
+            content = request.content();
+        }
+        if (title == null || title.length() < TITLE_MIN_LENGTH || title.length() > TITLE_MAX_LENGTH) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_TITLE_LENGTH_INVALID);
+        }
+        if (content == null || content.length() < CONTENT_MIN_LENGTH || content.length() > CONTENT_MAX_LENGTH) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_CONTENT_LENGTH_INVALID);
+        }
+        if (mainImage == null || mainImage.isEmpty()) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED);
+        }
+        int imageCount = (!mainImage.isEmpty() ? 1 : 0)
+                + (imageFiles != null ? (int) imageFiles.stream().filter(f -> f != null && !f.isEmpty()).count() : 0);
+        if (imageCount > MAX_IMAGE_COUNT) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED);
+        }
+        if (!mainImage.isEmpty()) {
+            if (mainImage.getSize() > MAX_IMAGE_SIZE) {
+                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+            }
+            String contentType = mainImage.getContentType();
+            if (contentType == null || !contentType.startsWith("image/")) {
+                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
+            }
+        }
+        if (imageFiles != null) {
+            for (MultipartFile file : imageFiles) {
+                if (file != null && !file.isEmpty()) {
+                    if (file.getSize() > MAX_IMAGE_SIZE) {
+                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+                    }
+                    String contentType = file.getContentType();
+                    if (contentType == null || !contentType.startsWith("image/")) {
+                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/java/DNBN/spring/aop/ArticleCreateValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleCreateValidationAspect.java
@@ -2,7 +2,6 @@ package DNBN.spring.aop;
 
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
-import DNBN.spring.apiPayload.exception.handler.ArticlePhotoHandler;
 import DNBN.spring.web.dto.ArticleRequestDTO;
 import DNBN.spring.web.dto.ArticleWithLocationRequestDTO;
 import org.aspectj.lang.JoinPoint;
@@ -10,9 +9,6 @@ import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-import org.springframework.web.multipart.MultipartFile;
-
-import java.util.List;
 
 @Aspect
 @Component
@@ -25,18 +21,11 @@ public class ArticleCreateValidationAspect {
     private int contentMinLength;
     @Value("${article.validation.content.max-length}")
     private int contentMaxLength;
-    @Value("${article.validation.image.max-count}")
-    private int maxImageCount;
-    @Value("${article.validation.image.max-size}")
-    private long maxImageSize;
 
     @Before("execution(* DNBN.spring.service.ArticleService.ArticleCommandServiceImpl.createArticle(..))")
     public void validateCreateArticle(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         Object dto = args[1];
-        MultipartFile mainImage = (MultipartFile) args[2];
-        List<MultipartFile> imageFiles = (List<MultipartFile>) args[3];
-
         String title = null;
         String content = null;
         if (dto instanceof ArticleRequestDTO request) {
@@ -51,36 +40,6 @@ public class ArticleCreateValidationAspect {
         }
         if (content == null || content.length() < contentMinLength || content.length() > contentMaxLength) {
             throw new ArticleHandler(ErrorStatus.ARTICLE_CONTENT_LENGTH_INVALID);
-        }
-        if (mainImage == null || mainImage.isEmpty()) {
-            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED);
-        }
-        int imageCount = (!mainImage.isEmpty() ? 1 : 0)
-                + (imageFiles != null ? (int) imageFiles.stream().filter(f -> f != null && !f.isEmpty()).count() : 0);
-        if (imageCount > maxImageCount) {
-            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED);
-        }
-        if (!mainImage.isEmpty()) {
-            if (mainImage.getSize() > maxImageSize) {
-                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
-            }
-            String contentType = mainImage.getContentType();
-            if (contentType == null || !contentType.startsWith("image/")) {
-                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
-            }
-        }
-        if (imageFiles != null) {
-            for (MultipartFile file : imageFiles) {
-                if (file != null && !file.isEmpty()) {
-                    if (file.getSize() > maxImageSize) {
-                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
-                    }
-                    String contentType = file.getContentType();
-                    if (contentType == null || !contentType.startsWith("image/")) {
-                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
-                    }
-                }
-            }
         }
     }
 }

--- a/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
@@ -1,0 +1,67 @@
+package DNBN.spring.aop;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticlePhotoHandler;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+/**
+ * S3 이미지 업로드 관련 공통 검증 Aspect
+ * (파일 개수, 크기, 타입 등)
+ */
+@Aspect
+@Component
+public class S3ImageValidationAspect {
+    @Value("${article.validation.image.max-count}")
+    private int maxImageCount;
+    @Value("${article.validation.image.max-size}")
+    private long maxImageSize;
+
+    @Before("execution(* *(.., org.springframework.web.multipart.MultipartFile, java.util.List, ..)) && @annotation(DNBN.spring.aop.annotation.ValidateS3ImageUpload)")
+    public void validateS3ImageUpload(JoinPoint joinPoint) {
+        Object[] args = joinPoint.getArgs();
+        MultipartFile mainImage = null;
+        List<MultipartFile> imageFiles = null;
+        for (Object arg : args) {
+            if (mainImage == null && arg instanceof MultipartFile file) {
+                mainImage = file;
+            } else if (imageFiles == null && arg instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof MultipartFile) {
+                imageFiles = (List<MultipartFile>) list;
+            }
+        }
+        int imageCount = (mainImage != null && !mainImage.isEmpty() ? 1 : 0)
+                + (imageFiles != null ? (int) imageFiles.stream().filter(f -> f != null && !f.isEmpty()).count() : 0);
+        if (imageCount > maxImageCount) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED);
+        }
+        if (mainImage != null && !mainImage.isEmpty()) {
+            if (mainImage.getSize() > maxImageSize) {
+                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+            }
+            String contentType = mainImage.getContentType();
+            if (contentType == null || !contentType.startsWith("image/")) {
+                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
+            }
+        }
+        if (imageFiles != null) {
+            for (MultipartFile file : imageFiles) {
+                if (file != null && !file.isEmpty()) {
+                    if (file.getSize() > maxImageSize) {
+                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+                    }
+                    String contentType = file.getContentType();
+                    if (contentType == null || !contentType.startsWith("image/")) {
+                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/src/main/java/DNBN/spring/aop/annotation/ValidateS3ImageUpload.java
+++ b/src/main/java/DNBN/spring/aop/annotation/ValidateS3ImageUpload.java
@@ -1,0 +1,15 @@
+package DNBN.spring.aop.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * S3 이미지 업로드 검증을 위한 커스텀 어노테이션
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidateS3ImageUpload {
+}
+

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -26,7 +26,6 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -36,18 +35,6 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional
 public class ArticleCommandServiceImpl implements ArticleCommandService {
-    @Value("${article.validation.image.max-count}")
-    private int maxImageCount;
-    @Value("${article.validation.image.max-size}")
-    private long maxImageSize;
-    @Value("${article.validation.title.min-length}")
-    private int titleMinLength;
-    @Value("${article.validation.title.max-length}")
-    private int titleMaxLength;
-    @Value("${article.validation.content.min-length}")
-    private int contentMinLength;
-    @Value("${article.validation.content.max-length}")
-    private int contentMaxLength;
 
     private final ArticleRepository articleRepository;
     private final ArticlePhotoRepository articlePhotoRepository;
@@ -57,7 +44,6 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     private final RegionRepository regionRepository;
     private final AmazonS3Manager s3Manager;
 
-    // TODO: 함수 및 클래스로 분리하기 (아래의 오버로딩 함수 포함)
     @Override
     public ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
@@ -76,8 +62,8 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     public ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
-        Place place = getPlace(request.placeId());
-        Region region = findOrCreateRegionByLatLng(request.latitude(), request.longitude());
+        Place place = getPlace(request.placeId()); // TODO: 🚩🚩🚩🚩🚩
+        Region region = findOrCreateRegionByLatLng(request.latitude(), request.longitude()); // TODO: 🚩🚩🚩🚩🚩
 
         Article article = createArticleEntity(member, category, place, region, request);
         articleRepository.save(article);
@@ -102,6 +88,8 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         return regionRepository.findById(regionId)
                 .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
     }
+
+    // TODO: 팩토리 검토
     private Article createArticleEntity(Member member, Category category, Place place, Region region, ArticleRequestDTO request) {
         return Article.builder()
                 .member(member)
@@ -128,6 +116,8 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
                 .spamCount(0L)
                 .build();
     }
+
+    // TODO: SRP 위반
     private List<ArticlePhoto> handleImages(Article article, Place place, Region region, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         List<ArticlePhoto> photos = new ArrayList<>();
         List<String> uploadedKeys = new ArrayList<>();
@@ -185,10 +175,9 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         return photos;
     }
 
-    // TODO: 지역 생성 API 구현 후 수정 필요
-    // 임시 지역 생성 메소드
+    // TODO: SRP 위반
+    // TODO: 임시 지역 생성 메소드 - 연결 후 삭제 필요
     private Region findOrCreateRegionByLatLng(Double latitude, Double longitude) {
-        // TODO: 실제 구현 필요 (예: 외부 행정구역 API 호출, DB 조회 등)
         String province = "서울";
         String city = "강남구";
         String district = latitude + "," + longitude;

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -35,12 +36,18 @@ import org.springframework.web.multipart.MultipartFile;
 @RequiredArgsConstructor
 @Transactional
 public class ArticleCommandServiceImpl implements ArticleCommandService {
-    private static final int MAX_IMAGE_COUNT = 10;
-    private static final long MAX_IMAGE_SIZE = 10 * 1024 * 1024; // 10MB
-    private static final int TITLE_MIN_LENGTH = 2;
-    private static final int TITLE_MAX_LENGTH = 100;
-    private static final int CONTENT_MIN_LENGTH = 10;
-    private static final int CONTENT_MAX_LENGTH = 5000;
+    @Value("${article.validation.image.max-count}")
+    private int maxImageCount;
+    @Value("${article.validation.image.max-size}")
+    private long maxImageSize;
+    @Value("${article.validation.title.min-length}")
+    private int titleMinLength;
+    @Value("${article.validation.title.max-length}")
+    private int titleMaxLength;
+    @Value("${article.validation.content.min-length}")
+    private int contentMinLength;
+    @Value("${article.validation.content.max-length}")
+    private int contentMaxLength;
 
     private final ArticleRepository articleRepository;
     private final ArticlePhotoRepository articlePhotoRepository;

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package DNBN.spring.service.ArticleService;
 
+import DNBN.spring.aop.annotation.ValidateS3ImageUpload;
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
 import DNBN.spring.apiPayload.exception.handler.ArticlePhotoHandler;
@@ -45,6 +46,7 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     private final AmazonS3Manager s3Manager;
 
     @Override
+    @ValidateS3ImageUpload
     public ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
@@ -59,10 +61,11 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     }
 
     @Override
+    @ValidateS3ImageUpload
     public ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
-        Place place = getPlace(request.placeId()); // TODO: 🚩🚩🚩🚩🚩
+        Place place = getPlace(request.placeId()); // TODO: ??????????
         Region region = findOrCreateRegionByLatLng(request.latitude(), request.longitude()); // TODO: 🚩🚩🚩🚩🚩
 
         Article article = createArticleEntity(member, category, place, region, request);
@@ -176,7 +179,7 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     }
 
     // TODO: SRP 위반
-    // TODO: 임시 지역 생성 메소드 - 연결 후 삭제 필요
+    // TODO: 임시 ���역 생성 메소드 - 연결 후 삭제 필요
     private Region findOrCreateRegionByLatLng(Double latitude, Double longitude) {
         String province = "서울";
         String city = "강남구";

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -1,5 +1,6 @@
 package DNBN.spring.service.MemberService;
 
+import DNBN.spring.aop.annotation.ValidateS3ImageUpload;
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.apiPayload.exception.handler.RegionHandler;
@@ -42,6 +43,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
+    @ValidateS3ImageUpload
     public Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage) {
         // 기존 회원이 존재하는지를 따짐
         Member member = memberRepository.findById(memberId)
@@ -167,7 +169,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         }
 
 //        member.setNickname(newNickname);
-        member.updateNickname(newNickname); // 도메인 주도 설계(Domain-Driven Design) 원칙에 부합하도록
+        member.updateNickname(newNickname); // 도메인 ��도 설계(Domain-Driven Design) 원칙에 부합하도록
     }
 
     @Override
@@ -207,6 +209,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
+    @ValidateS3ImageUpload
     public MemberResponseDTO.ProfileImageUpdateResultDTO updateProfileImage(Long memberId, MultipartFile profileImage) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
@@ -2,6 +2,8 @@ package DNBN.spring.web.dto;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -24,6 +26,24 @@ public class ArticleResponseDTO {
     private String createdAt;
     private String updatedAt;
 
+    public ArticleResponseDTO(Long articleId, Long memberId, Long categoryId, Long placeId, Long regionId, String title, LocalDate date, String content, String mainImageUuid, List<String> imageUuids, Long likeCount, Long spamCount, String createdAt, String updatedAt) {
+        this.articleId = articleId;
+        this.memberId = memberId;
+        this.categoryId = categoryId;
+        this.placeId = placeId;
+        this.regionId = regionId;
+        this.title = title;
+        this.date = date;
+        this.content = content;
+        this.mainImageUuid = mainImageUuid;
+        // 방어적 복사
+        this.imageUuids = imageUuids == null ? null : List.copyOf(imageUuids);
+        this.likeCount = likeCount;
+        this.spamCount = spamCount;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    }
+
     @Builder
     @Getter
     public static class ArticlePreviewDTO {
@@ -34,6 +54,16 @@ public class ArticleResponseDTO {
         private Long likes;
         private Long spam;
         private Long comments;
+
+        public ArticlePreviewDTO(Long articleId, String pinCategory, String imageUrl, String title, Long likes, Long spam, Long comments) {
+            this.articleId = articleId;
+            this.pinCategory = pinCategory;
+            this.imageUrl = imageUrl;
+            this.title = title;
+            this.likes = likes;
+            this.spam = spam;
+            this.comments = comments;
+        }
     }
 
     @Builder
@@ -43,7 +73,13 @@ public class ArticleResponseDTO {
         private Long cursor;
         private Long limit;
         private boolean hasNext;
+
+        public ArticleListDTO(List<ArticlePreviewDTO> articles, Long cursor, Long limit, boolean hasNext) {
+            // 방어적 복사
+            this.articles = articles == null ? null : List.copyOf(articles);
+            this.cursor = cursor;
+            this.limit = limit;
+            this.hasNext = hasNext;
+        }
     }
-
 }
-

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -102,3 +102,14 @@ cloud:
     credentials:
       accessKey: ${AWS_ACCESS_KEY}
       secretKey: ${AWS_SECRET_KEY}
+article:
+  validation:
+    title:
+      min-length: 2
+      max-length: 100
+    content:
+      min-length: 10
+      max-length: 5000
+    image:
+      max-count: 10
+      max-size: 10485760 # 10MB (byte)


### PR DESCRIPTION
## #️⃣ 기능 설명
>  `ArticleCommandServiceImpl`의 게시물 생성 공통 로직 및 검증 로직 리팩토링 (메소드 분리 및 AOP)

## 🛠️ 작업 상세 내용
- [x] 게시물 생성 검증(제목/내용 길이, 이미지 개수/타입 등)을 AOP로 분리(Aspect 클래스 생성)
- [x] `ArticleCommandServiceImpl`의 `createArticle`들에서 공통 로직(private 메소드)로 분리
- [x] 서비스 내 검증 코드 제거 및 비즈니스 로직만 남기기
- [x] 게시글 생성 검증 상수 application.yml 설정값 분리 및 `@Value` 주입
- [x] S3 이미지 검증 로직을 분리해 다른 API에서 재사용 가능하게 하기
- [x] `ArticleResonseDTO`의 컬렉션에 방어적 복사 적용

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 원래는 하나의 api로 구현해 분기 처리하려 하였으나, api 변경 요구가 잦은 상황이여서 두개의 api로 분리한 상황입니다.
- 게시물 생성의 두 api가 거의 동일한 흐름이여서 중복 코드가 많은 상황이었습니다.
- 전략 패턴 도입을 고려하였으나, 분기된 부분이 단순한 지역 생성이어서 과하다 생각해 반려하였습니다.
- 변경된 API에 대한 수정은 아래 이슈로 이어짐
- #79 
### 테스트에 필요한 링크
http://localhost:8080/oauth2/authorization/kakao
http://localhost:8080/oauth2/authorization/naver
http://localhost:8080/oauth2/authorization/google