### PR TITLE
🔨 [Fix] 지도 화면 내 저장된 장소 조회 API - response body 수정

### DIFF
--- a/src/main/java/DNBN/spring/converter/PlaceConverter.java
+++ b/src/main/java/DNBN/spring/converter/PlaceConverter.java
@@ -33,6 +33,7 @@ public class PlaceConverter {
                         .latitude(p.getLatitude())
                         .longitude(p.getLongitude())
                         .pinCategory(p.getPinCategory().name())
+                        .address(p.getAddress())
                         .build())
                 .collect(Collectors.toList());
         return PlaceResponseDTO.MapPlacesResultDTO.builder()

--- a/src/main/java/DNBN/spring/domain/Place.java
+++ b/src/main/java/DNBN/spring/domain/Place.java
@@ -58,6 +58,9 @@ public class Place extends BaseEntity {
   @Enumerated(EnumType.STRING)
   private PinCategory pinCategory;
 
+  @Column(nullable = false, length = 255)
+  private String address;
+
   @OneToMany(mappedBy = "place", cascade = CascadeType.ALL, orphanRemoval = true)
   private List<SavePlace> savedPlaces = new ArrayList<>();
 }

--- a/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
@@ -45,6 +45,7 @@ public class PlaceResponseDTO {
         private Double latitude;
         private Double longitude;
         private String pinCategory;
+        private String address;
     }
 
     @Builder


### PR DESCRIPTION
## #️⃣ 기능 설명
> 지도 화면 내 저장된 장소 조회 API - response body 수정

## 🛠️ 작업 상세 내용
- [x] Place 클래스에 address 필드 및 JPA 매핑 추가
- [x] PlaceResponseDTO.MapPlaceDTO에 address 필드 추가
- [x] PlaceConverter.toMapPlacesResult()에서 p.getAddress()를 address로 매핑

## 📸 스크린샷 (선택)
<img width="1053" height="416" alt="스크린샷 2025-07-30 오후 11 35 29" src="https://github.com/user-attachments/assets/9e0e0b4e-61de-44ab-8c98-83d117270b6a" />

<img width="2104" height="308" alt="image" src="https://github.com/user-attachments/assets/a7f04d41-cac1-4d12-9b88-10f2976720a9" />


## 💬 기타(공유사항 to 리뷰어)
http://localhost:8080/oauth2/authorization/kakao

- 소수점 5번째 이상으로 입력 시 PLACE4002 "소수점 5자리까지만 입력 가능합니다." 에러 발생
