### PR TITLE
[Fix] 지도 화면 내 핀 등록된 장소 조회 시 저장 여부 알려주는 필드 추가, 장소 저장 로직 수정

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -63,7 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
 
     // 장소
-    CATEGORY_ALREADY_SAVED_FOR_PLACE(HttpStatus.CONFLICT, "SAVE_PLACE4001", "이미 해당 장소가 이 카테고리에 저장되어 있습니다."),
+    CATEGORY_ALREADY_SAVED_FOR_PLACE(HttpStatus.CONFLICT, "SAVE_PLACE4001", "이미 해당 장소가 저장되어 있습니다."),
     PLACE_NOT_FOUND(HttpStatus.NOT_FOUND, "PLACE4001", "해당 장소를 찾을 수 없습니다."),
     COORDINATE_PRECISION_INVALID(HttpStatus.BAD_REQUEST, "PLACE4002", "소수점 5자리까지만 입력 가능합니다."),
     PIN_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "PLACE4003", "유효하지 않은 핀 카테고리입니다."),

--- a/src/main/java/DNBN/spring/converter/PlaceConverter.java
+++ b/src/main/java/DNBN/spring/converter/PlaceConverter.java
@@ -2,6 +2,7 @@ package DNBN.spring.converter;
 
 import DNBN.spring.domain.Place;
 import DNBN.spring.domain.mapping.SavePlace;
+import DNBN.spring.repository.SavePlaceRepository.SavePlaceRepository;
 import DNBN.spring.web.dto.PlaceResponseDTO;
 
 import java.util.List;
@@ -25,17 +26,28 @@ public class PlaceConverter {
                 .collect(Collectors.toList());
     }
 
-    public static PlaceResponseDTO.MapPlacesResultDTO toMapPlacesResult(List<Place> places) {
+    public static PlaceResponseDTO.MapPlacesResultDTO toMapPlacesResult(
+            List<Place> places,
+            Long memberId,
+            SavePlaceRepository savePlaceRepository
+    ) {
         List<PlaceResponseDTO.MapPlaceDTO> list = places.stream()
-                .map(p -> PlaceResponseDTO.MapPlaceDTO.builder()
-                        .placeId(p.getPlaceId())
-                        .title(p.getTitle())
-                        .latitude(p.getLatitude())
-                        .longitude(p.getLongitude())
-                        .pinCategory(p.getPinCategory().name())
-                        .address(p.getAddress())
-                        .build())
+                .map(p -> {
+                    boolean saved = savePlaceRepository
+                            .existsByPlace_PlaceIdAndCategory_Member_Id(p.getPlaceId(), memberId);
+                    return PlaceResponseDTO.MapPlaceDTO.builder()
+                            .placeId(p.getPlaceId())
+                            .regionId(p.getRegion().getId())
+                            .title(p.getTitle())
+                            .latitude(p.getLatitude())
+                            .longitude(p.getLongitude())
+                            .pinCategory(p.getPinCategory().name())
+                            .address(p.getAddress())
+                            .saved(saved)
+                            .build();
+                })
                 .collect(Collectors.toList());
+
         return PlaceResponseDTO.MapPlacesResultDTO.builder()
                 .places(list)
                 .build();

--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
@@ -8,6 +8,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SavePlaceRepository extends JpaRepository<SavePlace, Long>, SavePlaceRepositoryCustom {
-    List<SavePlace> findByCategory(Category category);
-    boolean existsByPlaceAndCategory(Place place, Category category);
+    boolean existsByPlace(Place place);
+    boolean existsByPlace_PlaceIdAndCategory_Member_Id(Long placeId, Long memberId);
 }

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceCommandServiceImpl.java
@@ -44,8 +44,8 @@ public class PlaceCommandServiceImpl implements PlaceCommandService {
                 .findByCategoryIdAndMemberAndDeletedAtIsNull(request.getCategoryId(), member)
                 .orElseThrow(() -> new CategoryHandler(ErrorStatus._FORBIDDEN));
 
-        // 4. 중복 저장 여부 확인
-        if (savePlaceRepository.existsByPlaceAndCategory(place, category)) {
+        // 4. 이미 다른 카테고리에 저장된 장소인지 검사
+        if (savePlaceRepository.existsByPlace(place)) {
             throw new PlaceHandler(ErrorStatus.CATEGORY_ALREADY_SAVED_FOR_PLACE);
         }
 

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryService.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryService.java
@@ -5,11 +5,9 @@ import DNBN.spring.web.dto.PlaceResponseDTO;
 
 public interface PlaceQueryService {
     PlaceResponseDTO.SavedPlaceListDTO getSavedPlaces(Long categoryId, Long memberId, Long cursor, Long limit);
-//    PlaceResponseDTO.MapPlacesResultDTO getPlacesInMapBounds(PlaceRequestDTO.MapSearchDTO request);
     PlaceResponseDTO.MapPlacesResultDTO getPlacesInMapBounds(
-        Double latMin,
-        Double latMax,
-        Double lngMin,
-        Double lngMax
+            Long memberId,
+            Double latMin, Double latMax,
+            Double lngMin, Double lngMax
     );
 }

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
@@ -64,15 +64,14 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
 
     @Override
     public PlaceResponseDTO.MapPlacesResultDTO getPlacesInMapBounds(
-            Double latMin,
-            Double latMax,
-            Double lngMin,
-            Double lngMax
+            Long memberId, Double latMin, Double latMax, Double lngMin, Double lngMax
     ) {
         List<Place> places = placeRepositoryCustom.findAllInBounds(
-                latMin, latMax,
-                lngMin, lngMax
+                latMin, latMax, lngMin, lngMax
         );
-        return PlaceConverter.toMapPlacesResult(places);
+
+        return PlaceConverter.toMapPlacesResult(
+                places, memberId, savePlaceRepository
+        );
     }
 }

--- a/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/PlaceRestController.java
@@ -90,10 +90,14 @@ public class PlaceRestController {
             @Digits(integer = 3, fraction = 5, message = "COORDINATE_PRECISION_INVALID")
             Double lngMax
     ) {
-        placeQueryService.getPlacesInMapBounds(latMin, latMax, lngMin, lngMax);
-        return ResponseEntity.ok(ApiResponse.onSuccess(
-                placeQueryService.getPlacesInMapBounds(latMin, latMax, lngMin, lngMax)
-        ));
+        // 1) 토큰에서 memberId 추출
+        Long memberId = extractMemberIdFromToken(request);
+
+        // 2) 서비스에 memberId 포함하여 한 번만 호출
+        PlaceResponseDTO.MapPlacesResultDTO result = placeQueryService.getPlacesInMapBounds(memberId, latMin, latMax, lngMin, lngMax);
+
+        // 3) 응답 리턴
+        return ResponseEntity.ok(ApiResponse.onSuccess(result));
     }
 
     private Long extractMemberIdFromToken(HttpServletRequest request) {

--- a/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/PlaceResponseDTO.java
@@ -1,5 +1,6 @@
 package DNBN.spring.web.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -41,11 +42,14 @@ public class PlaceResponseDTO {
     @Getter
     public static class MapPlaceDTO {
         private Long placeId;
+        private Long regionId;
         private String title;
         private Double latitude;
         private Double longitude;
         private String pinCategory;
         private String address;
+        @JsonProperty("isSaved")
+        private boolean saved;
     }
 
     @Builder


### PR DESCRIPTION
## #️⃣ 기능 설명
> 추가하려는 기능에 대해 간결하게 설명해주세요

## 🛠️ 작업 상세 내용
- [x] MapPlaceDTO에 regionId와 장소 저장 여부를 담는 saved 필드 추가
- [x] saved 필드에 @JsonProperty("isSaved")를 붙여 JSON엔 isSaved로만 노출되게 함
- [x] PlaceConverter.toMapPlacesResult에 memberId를 넘겨savePlaceRepository.existsByPlace_PlaceIdAndCategory_Member_Id(...)로 saved 값을 설정
- [x] PlaceQueryService 및 컨트롤러에서 토큰으로부터 추출한 memberId를 getPlacesInMapBounds에 함께 전달하도록 수정
- [x] SavePlaceRepository에 existsByPlace_PlaceIdAndCategory_Member_Id(Long placeId, Long memberId) 메서드를 추가
- [x] 장소 저장 로직 변경 -> 장소는 본인의 카테고리 중 하나의 카테고리에만 저장 가능

## 📸 스크린샷 (선택)
<img width="1059" height="404" alt="스크린샷 2025-08-01 오전 1 09 40" src="https://github.com/user-attachments/assets/48d57bb1-3d7c-4d5c-87df-08a33f63dc30" />

## 💬 기타(공유사항 to 리뷰어)
http://localhost:8080/oauth2/authorization/kakao
