### PR TITLE
🔨 [Fix] ArticleController 성공 응답 방식 통일

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -25,7 +25,7 @@ public enum SuccessStatus implements BaseCode {
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),
 
     // 댓글
-    COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
+    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
     COMMENT_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
 
     // 동네 검색

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -29,7 +29,11 @@ public enum SuccessStatus implements BaseCode {
     COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
 
     // 동네 검색
-    REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다.")
+    REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다."),
+
+    // 게시물 관련 응답
+    ARTICLE_CREATE_SUCCESS(HttpStatus.OK, "ARTICLE_CREATE_SUCCESS", "게시물이 정상적으로 작성되었습니다."),
+    ARTICLE_DELETE_SUCCESS(HttpStatus.OK, "ARTICLE_DELETE_SUCCESS", "게시물이 정상적으로 삭제되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -26,7 +26,7 @@ public enum SuccessStatus implements BaseCode {
 
     // 댓글
     COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
-    COMMENT_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
+    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
 
     // 동네 검색
     REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -25,14 +25,14 @@ public enum SuccessStatus implements BaseCode {
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.OK, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),
 
     // 댓글
-    COMMENT_CREATE_SUCCESS(HttpStatus.OK, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
+    COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
     COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
 
     // 동네 검색
     REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다."),
 
     // 게시물 관련 응답
-    ARTICLE_CREATE_SUCCESS(HttpStatus.OK, "ARTICLE_CREATE_SUCCESS", "게시물이 정상적으로 작성되었습니다."),
+    ARTICLE_CREATE_SUCCESS(HttpStatus.CREATED, "ARTICLE_CREATE_SUCCESS", "게시물이 정상적으로 작성되었습니다."),
     ARTICLE_DELETE_SUCCESS(HttpStatus.OK, "ARTICLE_DELETE_SUCCESS", "게시물이 정상적으로 삭제되었습니다.")
     ;
 

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -26,14 +26,14 @@ public enum SuccessStatus implements BaseCode {
 
     // 댓글
     COMMENT_CREATE_SUCCESS(HttpStatus.CREATED, "COMMENT_CREATE_SUCCESS", "댓글이 정상적으로 작성되었습니다."),
-    COMMENT_DELETE_SUCCESS(HttpStatus.OK, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
+    COMMENT_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "COMMENT_DELETE_SUCCESS", "댓글이 정상적으로 삭제되었습니다."),
 
     // 동네 검색
     REGION_SEARCH_SUCCESS(HttpStatus.OK, "REGION2001", "지역 검색 결과입니다."),
 
     // 게시물 관련 응답
     ARTICLE_CREATE_SUCCESS(HttpStatus.CREATED, "ARTICLE_CREATE_SUCCESS", "게시물이 정상적으로 작성되었습니다."),
-    ARTICLE_DELETE_SUCCESS(HttpStatus.OK, "ARTICLE_DELETE_SUCCESS", "게시물이 정상적으로 삭제되었습니다.")
+    ARTICLE_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "ARTICLE_DELETE_SUCCESS", "게시물이 정상적으로 삭제되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -1,6 +1,7 @@
 package DNBN.spring.web.controller;
 
 import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.apiPayload.code.status.SuccessStatus;
 import DNBN.spring.converter.ArticleConverter;
 import DNBN.spring.domain.MemberDetails;
 import DNBN.spring.service.ArticleService.ArticleCommandService;
@@ -43,7 +44,7 @@ public class ArticleController {
         Long memberId = memberDetails.getMember().getId();
         ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, dto, mainImage, imageFiles);
         ArticleResponseDTO response = ArticleConverter.toArticleResponseDTO(result.article, result.photos);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.of(SuccessStatus.ARTICLE_CREATE_SUCCESS, response);
     }
 
     @PostMapping(value = "/with-location", consumes = {"multipart/form-data"})
@@ -61,7 +62,7 @@ public class ArticleController {
         Long memberId = memberDetails.getMember().getId();
         ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, dto, mainImage, imageFiles);
         ArticleResponseDTO response = ArticleConverter.toArticleResponseDTO(result.article, result.photos);
-        return ApiResponse.onSuccess(response);
+        return ApiResponse.of(SuccessStatus.ARTICLE_CREATE_SUCCESS, response);
     }
 
     @DeleteMapping("/{articleId}")
@@ -76,6 +77,6 @@ public class ArticleController {
     ) {
         Long memberId = memberDetails.getMember().getId();
         articleCommandService.deleteArticle(memberId, articleId);
-        return ApiResponse.onSuccess(null);
+        return ApiResponse.of(SuccessStatus.ARTICLE_DELETE_SUCCESS, null);
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
>게시물 API 성공 응답 반환 방식 통일 및 커스텀 SuccessStatus 적용

## 🛠️ 작업 상세 내용
- [x] `ArticleController`의 성공 응답을 `ApiResponse.of(SuccessStatus.XXX, ...)` 형태로 통일

## 📸 스크린샷 (선택)
**게시물 생성:**
<img width="1182" height="745" alt="image" src="https://github.com/user-attachments/assets/698bc4f6-6765-4f60-842d-74ef57291473" />
**게시물 생성 (미등록 장소):**
<img width="1190" height="740" alt="image" src="https://github.com/user-attachments/assets/49c87499-4679-413a-ac04-09476961bf77" />
**게시물 삭제:**
<img width="1182" height="311" alt="image" src="https://github.com/user-attachments/assets/4e566023-c525-424d-94ee-ed9c6fab2cd8" />

## 💬 기타(공유사항 to 리뷰어)
- 기존 게시물 API는 성공 시 COMMON 코드로 응답하고 있어, 다른 API들과 동일하게 커스텀 SuccessStatus를 적용하여 응답의 알관성을 높였습니다.
- 직접 응답을 확인하기도 했고, 변경 사항에 오류 발생 가능성이 낮아 리뷰 없이 머지하겠습니다