### PR TITLE
✨ [Feat] 댓글 알림 조회, 삭제

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -14,7 +14,6 @@ public enum ErrorStatus implements BaseErrorCode {
     _BAD_REQUEST(HttpStatus.BAD_REQUEST,"COMMON4000","잘못된 요청입니다."),
     _UNAUTHORIZED(HttpStatus.UNAUTHORIZED,"COMMON4001","인증이 필요합니다."),
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON4003", "금지된 요청입니다."),
-
     ACCESS_DENIED(HttpStatus.FORBIDDEN, "COMMON4004", "권한이 없습니다."),
 
     // 멤버 관련 에러
@@ -45,21 +44,15 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // For test
     TEMP_EXCEPTION(HttpStatus.BAD_REQUEST, "TEMP4001", "이거는 테스트"),
-
     REGION_NOT_FOUND(HttpStatus.NOT_FOUND, "REGION4001", "해당 지역이 존재하지 않습니다."),
-
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "STORE4001", "가게가 없습니다."),
-
     PAGE_NOT_VALID(HttpStatus.BAD_REQUEST, "PAGE4001", "페이지는 1 이상이어야 합니다."),
 
     //jwt 토큰
     INVALID_JWT_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4001", "유효하지 않은 AccessToken입니다."),
     INVALID_JWT_REFRESH_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4002", "유효하지 않은 RefreshToken입니다."),
-
     INVALID_SOCIAL_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4003", "유효하지 않은 SocialToken입니다."),
-
     INVALID_CSRF_TOKEN(HttpStatus.UNAUTHORIZED, "TOKEN4004", "유효하지 않은 CSRF Token입니다."),
-
     INVALID_PASSWORD(HttpStatus.UNAUTHORIZED, "PW4001", "잘못된 비밀번호입니다."),
 
     // 장소
@@ -68,6 +61,8 @@ public enum ErrorStatus implements BaseErrorCode {
     COORDINATE_PRECISION_INVALID(HttpStatus.BAD_REQUEST, "PLACE4002", "소수점 5자리까지만 입력 가능합니다."),
     PIN_CATEGORY_INVALID(HttpStatus.BAD_REQUEST, "PLACE4003", "유효하지 않은 핀 카테고리입니다."),
 
+    // 알림
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "알림을 찾을 수 없습니다."),
 
     //like
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시물을 찾을 수 없습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -63,6 +63,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 알림
     NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION4001", "알림을 찾을 수 없습니다."),
+    NOTIFICATION_ALREADY_HIDDEN(HttpStatus.CONFLICT, "NOTIFICATION4002", "이미 삭제된 알림입니다."),
 
     //like
     POST_NOT_FOUND(HttpStatus.NOT_FOUND, "POST404", "해당 게시물을 찾을 수 없습니다."),

--- a/src/main/java/DNBN/spring/converter/NotificationConverter.java
+++ b/src/main/java/DNBN/spring/converter/NotificationConverter.java
@@ -1,0 +1,18 @@
+package DNBN.spring.converter;
+
+import DNBN.spring.domain.Notification;
+import DNBN.spring.web.dto.NotificationResponseDTO;
+
+public class NotificationConverter {
+    public static NotificationResponseDTO.Response toResponseDto(Notification notification) {
+        return NotificationResponseDTO.Response.builder()
+                .notificationId(notification.getId())
+                .commentId(notification.getComment().getCommentId())
+                .articleId(notification.getComment().getArticle().getArticleId())
+                .articleTitle(notification.getComment().getArticle().getTitle())
+                .commentContent(notification.getComment().getContent())
+                .commenterNickname(notification.getComment().getMember().getNickname())
+                .build();
+    }
+}
+

--- a/src/main/java/DNBN/spring/domain/Notification.java
+++ b/src/main/java/DNBN/spring/domain/Notification.java
@@ -1,0 +1,29 @@
+package DNBN.spring.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "notification")
+@Getter @Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Notification {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member; // 알림을 받는 유저
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "comment_id")
+    private Comment comment; // 댓글 알림용
+
+    private boolean hidden = false; // X 눌러 숨겼을 때 true
+
+    private LocalDateTime createdAt = LocalDateTime.now();
+}

--- a/src/main/java/DNBN/spring/domain/Notification.java
+++ b/src/main/java/DNBN/spring/domain/Notification.java
@@ -1,5 +1,6 @@
 package DNBN.spring.domain;
 
+import DNBN.spring.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -10,7 +11,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Notification {
+public class Notification extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -24,6 +25,4 @@ public class Notification {
     private Comment comment; // 댓글 알림용
 
     private boolean hidden = false; // X 눌러 숨겼을 때 true
-
-    private LocalDateTime createdAt = LocalDateTime.now();
 }

--- a/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepository.java
+++ b/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepository.java
@@ -1,0 +1,10 @@
+package DNBN.spring.repository.NotificationRepository;
+
+import DNBN.spring.domain.Notification;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface NotificationRepository extends JpaRepository<Notification, Long>, NotificationRepositoryCustom {
+    List<Notification> findByComment_CommentId(Long commentId);
+}

--- a/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepositoryCustom.java
@@ -1,0 +1,9 @@
+package DNBN.spring.repository.NotificationRepository;
+
+import DNBN.spring.domain.Notification;
+
+import java.util.List;
+
+public interface NotificationRepositoryCustom {
+    List<Notification> findByMemberAndHiddenFalseWithCursor(Long memberId, Long cursor, Long limit);
+}

--- a/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/NotificationRepository/NotificationRepositoryImpl.java
@@ -1,0 +1,32 @@
+package DNBN.spring.repository.NotificationRepository;
+
+import DNBN.spring.domain.Notification;
+import DNBN.spring.domain.QNotification;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class NotificationRepositoryImpl implements NotificationRepositoryCustom {
+    private final JPAQueryFactory query;
+    private final QNotification notif = QNotification.notification;
+
+    @Override
+    public List<Notification> findByMemberAndHiddenFalseWithCursor(Long memberId, Long cursor, Long limit) {
+        BooleanBuilder b = new BooleanBuilder()
+                .and(notif.member.id.eq(memberId))
+                .and(notif.hidden.isFalse());
+        if (cursor != null) {
+            b.and(notif.id.lt(cursor));
+        }
+        return query.selectFrom(notif)
+                .where(b)
+                .orderBy(notif.id.desc())
+                .limit(limit + 1)
+                .fetch();
+    }
+}

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -7,9 +7,11 @@ import DNBN.spring.converter.CommentConverter;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Comment;
 import DNBN.spring.domain.Member;
+import DNBN.spring.domain.Notification;
 import DNBN.spring.repository.ArticleRepository.ArticleRepository;
 import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.repository.NotificationRepository.NotificationRepository;
 import DNBN.spring.web.dto.CommentRequestDTO;
 import DNBN.spring.web.dto.CommentResponseDTO;
 import lombok.RequiredArgsConstructor;
@@ -22,6 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class CommentCommandServiceImpl implements CommentCommandService {
     private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
+    private final NotificationRepository notificationRepository;
 
     private static final int CONTENT_MIN_LENGTH = 2;
     private static final int CONTENT_MAX_LENGTH = 1000;
@@ -56,6 +59,19 @@ public class CommentCommandServiceImpl implements CommentCommandService {
                 .build();
 
         commentRepository.save(comment);
+
+        // (1) 원글 작성자
+        Member articleOwner = article.getMember();
+        // (2) 본인이 자신의 글에 댓글 단 경우 알림 보낼 필요 없으면 생략
+        if (!articleOwner.getId().equals(memberId)) {
+            Notification notification = Notification.builder()
+                    .member(articleOwner)
+                    .comment(comment)
+                    .hidden(false)
+                    .build();
+            notificationRepository.save(notification);
+        }
+
         return CommentConverter.toCommentResponseDTO(comment);
     }
 
@@ -75,5 +91,8 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         }
 
         comment.delete();
+
+        notificationRepository.findByComment_CommentId(commentId)
+                .forEach(notificationRepository::delete);
     }
 }

--- a/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandService.java
+++ b/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandService.java
@@ -1,0 +1,5 @@
+package DNBN.spring.service.NotificationService;
+
+public interface NotificationCommandService {
+    void hideNotification(Long memberId, Long notificationId);
+}

--- a/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandServiceImpl.java
@@ -24,7 +24,10 @@ public class NotificationCommandServiceImpl implements NotificationCommandServic
             throw new GeneralException(ErrorStatus.ACCESS_DENIED);
         }
 
+        if (n.isHidden()) {
+            throw new GeneralException(ErrorStatus.NOTIFICATION_ALREADY_HIDDEN);
+        }
+
         n.setHidden(true);
-        // JPA 영속성 컨텍스트가 관리하므로 save() 불필요
     }
 }

--- a/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/NotificationService/NotificationCommandServiceImpl.java
@@ -1,0 +1,30 @@
+package DNBN.spring.service.NotificationService;
+
+import DNBN.spring.apiPayload.exception.GeneralException;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.domain.Notification;
+import DNBN.spring.repository.NotificationRepository.NotificationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class NotificationCommandServiceImpl implements NotificationCommandService {
+
+    private final NotificationRepository repo;
+
+    @Override
+    public void hideNotification(Long memberId, Long notificationId) {
+        Notification n = repo.findById(notificationId)
+                .orElseThrow(() -> new GeneralException(ErrorStatus.NOTIFICATION_NOT_FOUND));
+
+        if (!n.getMember().getId().equals(memberId)) {
+            throw new GeneralException(ErrorStatus.ACCESS_DENIED);
+        }
+
+        n.setHidden(true);
+        // JPA 영속성 컨텍스트가 관리하므로 save() 불필요
+    }
+}

--- a/src/main/java/DNBN/spring/service/NotificationService/NotificationQueryService.java
+++ b/src/main/java/DNBN/spring/service/NotificationService/NotificationQueryService.java
@@ -1,0 +1,7 @@
+package DNBN.spring.service.NotificationService;
+
+import DNBN.spring.web.dto.NotificationResponseDTO;
+
+public interface NotificationQueryService {
+    NotificationResponseDTO.ListDTO getNotifications(Long memberId, Long cursor, Long limit);
+}

--- a/src/main/java/DNBN/spring/service/NotificationService/NotificationQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/NotificationService/NotificationQueryServiceImpl.java
@@ -1,0 +1,52 @@
+package DNBN.spring.service.NotificationService;
+
+import DNBN.spring.apiPayload.exception.GeneralException;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.converter.NotificationConverter;
+import DNBN.spring.domain.Notification;
+import DNBN.spring.repository.NotificationRepository.NotificationRepository;
+import DNBN.spring.web.dto.NotificationResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NotificationQueryServiceImpl implements NotificationQueryService {
+
+    private final NotificationRepository repo;
+
+    @Override
+    public NotificationResponseDTO.ListDTO getNotifications(Long memberId, Long cursor, Long limit) {
+        // 1) Custom Repo 로 페치 (limit+1)
+        List<Notification> list = repo
+                .findByMemberAndHiddenFalseWithCursor(memberId, cursor, limit);
+
+        // 2) hasNext 판별 & 마지막 한 건 제거
+        boolean hasNext = list.size() > limit;
+        if (hasNext) {
+            list.remove(list.size() - 1);
+        }
+
+        // 3) DTO 변환
+        List<NotificationResponseDTO.Response> dtos = list.stream()
+                .map(NotificationConverter::toResponseDto)
+                .toList();
+
+        // 4) nextCursor 계산
+        Long nextCursor = dtos.isEmpty()
+                ? null
+                : dtos.get(dtos.size() - 1).getNotificationId();
+
+        // 5) ListDTO 빌드
+        return NotificationResponseDTO.ListDTO.builder()
+                .notifications(dtos)
+                .cursor(nextCursor)
+                .limit(limit)
+                .hasNext(hasNext)
+                .build();
+    }
+}

--- a/src/main/java/DNBN/spring/web/controller/NotificationRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/NotificationRestController.java
@@ -1,0 +1,53 @@
+package DNBN.spring.web.controller;
+
+import DNBN.spring.apiPayload.ApiResponse;
+import DNBN.spring.domain.MemberDetails;
+import DNBN.spring.service.NotificationService.NotificationQueryService;
+import DNBN.spring.service.NotificationService.NotificationCommandService;
+import DNBN.spring.web.dto.NotificationResponseDTO;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/member/comments/notifications")
+@SecurityRequirement(name = "JWT TOKEN")
+public class NotificationRestController {
+
+    private final NotificationQueryService querySvc;
+    private final NotificationCommandService cmdSvc;
+
+    @Operation(summary = "댓글 알림 삭제", description = "사용자가 받은 특정 댓글 알림을 삭제합니다.")
+    @DeleteMapping("/{notificationId}")
+    public ApiResponse<Void> hide(
+            @AuthenticationPrincipal MemberDetails user,
+            @PathVariable Long notificationId) {
+
+        cmdSvc.hideNotification(user.getMember().getId(), notificationId);
+        return ApiResponse.onSuccess(null);
+    }
+
+    @Operation(summary = "댓글 알림 조회", description = "댓글 알림 목록을 커서 기반 페이징으로 조회합니다.")
+    @GetMapping
+    public ApiResponse<NotificationResponseDTO.ListDTO> list(
+            @AuthenticationPrincipal MemberDetails user,
+
+            @Parameter(
+                    name        = "cursor",
+                    description = "다음 페이지 요청 시 기준이 되는 notificationId (default: null) -> hasNext = true 이면, 응답받은 cursor 값 입력 필요",
+                    schema      = @Schema(type = "integer", format = "int64", defaultValue = "null")
+            )
+            @RequestParam(required = false) Long cursor,
+
+            @Parameter(name = "limit", description = "최대 응답 개수 (default: 20)", example = "20")
+            @RequestParam(defaultValue = "20") Long limit) {
+
+        var result = querySvc.getNotifications(user.getMember().getId(), cursor, limit);
+        return ApiResponse.onSuccess(result);
+    }
+}

--- a/src/main/java/DNBN/spring/web/dto/NotificationResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/NotificationResponseDTO.java
@@ -1,0 +1,30 @@
+package DNBN.spring.web.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+public class NotificationResponseDTO {
+
+    @Getter
+    @Builder
+    public static class Response {
+        private Long notificationId;
+        private Long articleId;
+        private String articleTitle;
+        private Long commentId;
+        private String commentContent;
+        private String commenterNickname;
+    }
+
+    @Getter
+    @Builder
+    public static class ListDTO {
+        private List<Response> notifications;
+        private Long cursor;
+        private Long limit;
+        private boolean hasNext;
+    }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 본인의 게시글에 달린 댓글 알림 목록 조회 - GET /api/member/comments/notifications 구현
> 특정 댓글 알림 삭제 - DELETE /api/member/comments/notifications/{notificationId} 구현

## 🛠️ 작업 상세 내용
- [x] Notification 엔티티와 테이블을 추가
- [x] 댓글 알림을 저장·관리할 수 있도록 Repository(Custom 포함)와 DTO/Converter를 구현
- [x] 댓글 알림 조회에서 hidden=false인 알림을 커서 페이징으로 조회하도록 NotificationQueryService와 Controller를 작성
- [x] 특정 댓글 알림 삭제 시 권한 검증 후 hidden 플래그를 true로 업데이트하는 NotificationCommandService와 Controller 로직을 구현

## 📸 스크린샷 (선택)
- 본인의 게시글에 달린 댓글 알림 목록 조회 성공
<img width="1066" height="425" alt="스크린샷 2025-08-01 오후 5 36 49" src="https://github.com/user-attachments/assets/bc2946cb-1b91-431c-bcbe-c03f518a3a7c" />

- 특정 댓글 알림 삭제 성공
<img width="1059" height="157" alt="스크린샷 2025-08-01 오후 6 59 48" src="https://github.com/user-attachments/assets/e78c07f8-d3e9-4f86-9807-a0d2480c0937" />

- 본인의 알림 제외 삭제 요청 시 에러
<img width="1064" height="157" alt="스크린샷 2025-08-01 오후 7 01 54" src="https://github.com/user-attachments/assets/d0f35481-516c-4afe-b826-aade0681aedb" />

- 중복 삭제 시 에러
<img width="1081" height="156" alt="스크린샷 2025-08-01 오후 7 29 53" src="https://github.com/user-attachments/assets/0eb3b0e4-d2fb-4eaa-ab2e-32ce2913e1c5" />


## 💬 기타(공유사항 to 리뷰어)
http://localhost:8080/oauth2/authorization/kakao

- 다른 사람이 본인의 게시글에 댓글 작성 했을 경우에만 알림 목록 조회 가능!