### PR TITLE
✨ [Feat] 게시물 목록 조회

### DIFF
--- a/src/main/java/DNBN/spring/converter/ArticleConverter.java
+++ b/src/main/java/DNBN/spring/converter/ArticleConverter.java
@@ -108,7 +108,7 @@ public class ArticleConverter {
                 .build();
     }
 
-    public static ArticleResponseDTO.ArticleListItemDTO toArticleListItemDTO(Article article, Long loginMemberId) {
+    public static ArticleResponseDTO.ArticleListItemDTO toArticleListItemDTO(Article article, String mainImageUuid, boolean isLiked, boolean isSpammed, boolean isMine) {
         return ArticleResponseDTO.ArticleListItemDTO.builder()
                 .memberId(article.getMember().getId())
                 .articleId(article.getArticleId())
@@ -117,13 +117,13 @@ public class ArticleConverter {
                 .nickname(article.getMember().getNickname())
                 .title(article.getTitle())
                 .pinCategory(article.getPlace().getPinCategory().name())
-                .mainImageUuid(null) // TODO: 대표 이미지 추출 로직 필요
+                .mainImageUuid(mainImageUuid)
                 .likeCount(article.getLikesCount())
                 .spamCount(article.getSpamCount())
                 .commentCount(article.getCommentCount())
-                .isLiked(false) // TODO: 좋아요 여부 조회
-                .isSpammed(false) // TODO: 스팸 여부 조회
-                .isMine(loginMemberId != null && loginMemberId.equals(article.getMember().getId()))
+                .isLiked(isLiked)
+                .isSpammed(isSpammed)
+                .isMine(isMine)
                 .createdAt(article.getCreatedAt().toString())
                 .updatedAt(article.getUpdatedAt().toString())
                 .build();

--- a/src/main/java/DNBN/spring/converter/ArticleConverter.java
+++ b/src/main/java/DNBN/spring/converter/ArticleConverter.java
@@ -107,4 +107,25 @@ public class ArticleConverter {
                 .updatedAt(article.getUpdatedAt().toString())
                 .build();
     }
+
+    public static ArticleResponseDTO.ArticleListItemDTO toArticleListItemDTO(Article article, Long loginMemberId) {
+        return ArticleResponseDTO.ArticleListItemDTO.builder()
+                .memberId(article.getMember().getId())
+                .articleId(article.getArticleId())
+                .regionId(article.getRegion().getId())
+                .placeId(article.getPlace().getPlaceId())
+                .nickname(article.getMember().getNickname())
+                .title(article.getTitle())
+                .pinCategory(article.getPlace().getPinCategory().name())
+                .mainImageUuid(null) // TODO: 대표 이미지 추출 로직 필요
+                .likeCount(article.getLikesCount())
+                .spamCount(article.getSpamCount())
+                .commentCount(article.getCommentCount())
+                .isLiked(false) // TODO: 좋아요 여부 조회
+                .isSpammed(false) // TODO: 스팸 여부 조회
+                .isMine(loginMemberId != null && loginMemberId.equals(article.getMember().getId()))
+                .createdAt(article.getCreatedAt().toString())
+                .updatedAt(article.getUpdatedAt().toString())
+                .build();
+    }
 }

--- a/src/main/java/DNBN/spring/repository/ArticlePhotoRepository/ArticlePhotoRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticlePhotoRepository/ArticlePhotoRepository.java
@@ -5,13 +5,13 @@ import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Member;
 import DNBN.spring.domain.Place;
 import DNBN.spring.domain.Region;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface ArticlePhotoRepository extends JpaRepository<ArticlePhoto, Long> {
     List<ArticlePhoto> findAllByArticle(Article article);
+    Optional<ArticlePhoto> findFirstByArticleAndIsMainTrue(Article article);
     List<ArticlePhoto> findAllByArticle_Member(Member member);
-    List<ArticlePhoto> findAllByPlace(Place place);
-    List<ArticlePhoto> findAllByRegion(Region region);
 }
 

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -20,7 +20,6 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     // TODO: PK 변수명 통일 필요 (id, placeId 등)
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
-
     Page<Article> findAllByPlace_PlaceIdIn(List<Long> placeIds, Pageable pageable);
 
     Optional<Article> findTopByHashtagOrderByLikesCountDescCreatedAtAsc(String keyword);

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -20,6 +20,8 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
 
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
 
+    Page<Article> findAllByPlace_IdIn(List<Long> placeIds, Pageable pageable);
+
     Optional<Article> findTopByHashtagOrderByLikesCountDescCreatedAtAsc(String keyword);
 
     List<Article> findByPlaceOrderByCreatedAtAsc(Place place);

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepository.java
@@ -18,9 +18,10 @@ public interface ArticleRepository extends JpaRepository<Article, Long> {
     List<Article> findAllByPlace(Place place);
     List<Article> findAllByRegion(Region region);
 
+    // TODO: PK 변수명 통일 필요 (id, placeId 등)
     Page<Article> findAllByRegion_IdIn(List<Long> regionIds, Pageable pageable);
 
-    Page<Article> findAllByPlace_IdIn(List<Long> placeIds, Pageable pageable);
+    Page<Article> findAllByPlace_PlaceIdIn(List<Long> placeIds, Pageable pageable);
 
     Optional<Article> findTopByHashtagOrderByLikesCountDescCreatedAtAsc(String keyword);
 

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
@@ -6,4 +6,6 @@ import java.util.List;
 
 public interface ArticleRepositoryCustom {
     List<Article> findArticlesByCategoryWithCursor(Long categoryId, Long cursor, Long limit);
+
+    List<Article> findArticlesByPlaceWithCursor(Long placeId, Long cursor, Long limit);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
@@ -34,4 +34,24 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                 .limit(limit)
                 .fetch();
     }
+
+    @Override
+    public List<Article> findArticlesByPlaceWithCursor(Long placeId, Long cursor, Long limit) {
+        QArticle article = QArticle.article;
+
+        BooleanBuilder builder = new BooleanBuilder();
+        builder.and(article.place.placeId.eq(placeId));
+        builder.and(article.deletedAt.isNull());
+
+        if (cursor != null) {
+            builder.and(article.articleId.lt(cursor));
+        }
+
+        return queryFactory
+            .selectFrom(article)
+            .where(builder)
+            .orderBy(article.createdAt.desc()) // 정적 필드로 정렬 (SQL Injection 위험 없음)
+            .limit(limit)
+            .fetch();
+    }
 }

--- a/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
@@ -11,6 +11,9 @@ import java.util.Optional;
 
 public interface PlaceRepository extends JpaRepository<Place, Long> {
     List<Place> findAllByRegion(Region region);
+
+    Optional<Place> findPlaceByPlaceId(Long placeId);
+
     Optional<Place> findByLatitudeAndLongitude(Double lat, Double lng);
 
     List<Place> findByRegionId(Long regionId);

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
@@ -15,4 +15,6 @@ public interface ArticleQueryService {
     PostResponseDTO.PostPreViewDTO getTopChallengeArticle();
 
     ArticleResponseDTO.ArticleDetailDTO getArticleDetail(Long articleId);
+
+    List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long regionId, Long cursor, Long limit);
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -81,6 +81,8 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
 
     @Override
     public ArticleResponseDTO.ArticleListDTO getArticlesByCategory(Long categoryId, Long memberId, Long cursor, Long limit) {
+        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT;
+
         // 1. 사용자 확인
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -90,9 +92,9 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                 .orElseThrow(() -> new CategoryHandler(ErrorStatus._FORBIDDEN));
 
         // 3. 게시물 조회 (limit + 1 조회로 hasNext 판별)
-        List<Article> articles = articleRepositoryCustom.findArticlesByCategoryWithCursor(categoryId, cursor, limit + 1);
+        List<Article> articles = articleRepositoryCustom.findArticlesByCategoryWithCursor(categoryId, cursor, effectiveLimit + 1);
 
-        boolean hasNext = articles.size() > limit;
+        boolean hasNext = articles.size() > effectiveLimit;
         if (hasNext) articles.remove(articles.size() - 1);
 
         // 4. 변환

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -83,6 +83,10 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     public ArticleResponseDTO.ArticleListDTO getArticlesByCategory(Long categoryId, Long memberId, Long cursor, Long limit) {
         long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT;
 
+        if (cursor == null || cursor == -1L) {
+            cursor = null;
+        }
+
         // 1. 사용자 확인
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
@@ -126,6 +130,10 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     @Override
     public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, Long cursor, Long limit) {
         long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT; // limit가 null인 경우 기본값 설정
+
+        if (cursor == null || cursor == -1L) {
+            cursor = null;
+        }
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -108,4 +108,12 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
         List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
         return ArticleConverter.toArticleDetailDTO(article, photos);
     }
+
+    @Override
+    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long regionId, Long cursor, Long limit) {
+        // regionId 기준으로 게시글 목록 조회 (soft delete 제외, cursor paging)
+        List<Article> articles = articleRepository.findAllByRegion_IdIn(List.of(regionId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
+        // TODO: cursor, limit, soft delete, 실제 페이징/정렬 로직 필요시 커스텀 쿼리로 대체
+        return articles.stream().map(article -> ArticleConverter.toArticleListItemDTO(article, memberId)).toList();
+    }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -117,8 +117,12 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     }
 
     @Override
-    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long regionId, Long cursor, Long limit) {
-        List<Article> articles = articleRepository.findAllByRegion_IdIn(List.of(regionId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
+    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, Long cursor, Long limit) {
+
+        // TODO: 검증 로직 추가
+        
+        // TODO: Cursor 기반 페이징 변경
+        List<Article> articles = articleRepository.findAllByPlace_IdIn(List.of(placeId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
 
         return articles.stream()
             .map(article -> {

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -45,7 +45,10 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ArticleQueryServiceImpl implements ArticleQueryService {
-    private static final String DEFAULT_IMAGE_UUID = "ae383fd6-4211-496b-a631-827954b03306";
+
+    @Value("${article.default-image-uuid}")
+    private String defaultImageUuid;
+
     private static final long DEFAULT_LIMIT = 10L;
 
     private final ArticleRepository articleRepository;
@@ -151,7 +154,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                 // 대표 이미지
                 String mainImageUuid = articlePhotoRepository.findFirstByArticleAndIsMainTrue(article)
                     .map(ArticlePhoto::getFileKey)
-                    .orElseGet(() -> DEFAULT_IMAGE_UUID);
+                    .orElseGet(() -> defaultImageUuid);
                 // 좋아요 여부
                 boolean isLiked = articleLikeRepository.existsById(
                     new ArticleLikeId(articleId, memberId)

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -28,6 +28,7 @@ import DNBN.spring.web.dto.ArticleResponseDTO;
 import DNBN.spring.web.dto.response.PostResponseDTO;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -41,6 +42,8 @@ import java.util.List;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ArticleQueryServiceImpl implements ArticleQueryService {
+    private static final String DEFAULT_IMAGE_UUID = "ae383fd6-4211-496b-a631-827954b03306";
+
     private final ArticleRepository articleRepository;
     private final LikeRegionRepository likeRegionRepository;
     private final CategoryRepository categoryRepository;
@@ -122,7 +125,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                 // 대표 이미지
                 String mainImageUuid = articlePhotoRepository.findFirstByArticleAndIsMainTrue(article)
                     .map(ArticlePhoto::getFileKey)
-                    .orElse("ae383fd6-4211-496b-a631-827954b03306"); // 기본 이미지 Uuid
+                    .orElseGet(() -> DEFAULT_IMAGE_UUID);
                 // 좋아요 여부
                 boolean isLiked = articleLikeRepository.existsById(
                     new ArticleLikeId(article.getArticleId(), memberId)

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -122,7 +122,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
         // TODO: 검증 로직 추가
         
         // TODO: Cursor 기반 페이징 변경
-        List<Article> articles = articleRepository.findAllByPlace_IdIn(List.of(placeId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
+        List<Article> articles = articleRepository.findAllByPlace_PlaceIdIn(List.of(placeId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
 
         return articles.stream()
             .map(article -> {
@@ -136,7 +136,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                 );
                 // 스팸 여부
                 boolean isSpammed = articleSpamRepository.existsById(
-                    new DNBN.spring.domain.ArticleSpamId(article.getArticleId(), memberId)
+                    new ArticleSpamId(article.getArticleId(), memberId)
                 );
                 // 내 글 여부
                 boolean isMine = memberId != null && memberId.equals(article.getMember().getId());

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -19,6 +19,7 @@ import DNBN.spring.repository.CategoryRepository.CategoryRepository;
 import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.repository.LikeRegionRepository.LikeRegionRepository;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.repository.PlaceRepository.PlaceRepository;
 import DNBN.spring.repository.RegionRepository.RegionRepository;
 import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
 import DNBN.spring.repository.ArticleSpamRepository.ArticleSpamRepository;
@@ -53,6 +54,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     private final MemberRepository memberRepository;
     private final ArticleLikeRepository articleLikeRepository;
     private final ArticleSpamRepository articleSpamRepository;
+    private final PlaceRepository placeRepository;
 
     @Override
     public Page<Article> getArticleListByRegion(Long memberId, Integer page) {
@@ -119,7 +121,10 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     @Override
     public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, Long cursor, Long limit) {
 
-        // TODO: 검증 로직 추가
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Place place = placeRepository.findPlaceByPlaceId(placeId)
+            .orElseThrow(() -> new ArticleHandler(ErrorStatus.PLACE_NOT_FOUND));
         
         // TODO: Cursor 기반 페이징 변경
         List<Article> articles = articleRepository.findAllByPlace_PlaceIdIn(List.of(placeId), PageRequest.of(0, limit.intValue(), Sort.by(Sort.Direction.DESC, "createdAt"))).getContent();
@@ -139,7 +144,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                     new ArticleSpamId(article.getArticleId(), memberId)
                 );
                 // 내 글 여부
-                boolean isMine = memberId != null && memberId.equals(article.getMember().getId());
+                boolean isMine = memberId.equals(article.getMember().getId());
 
                 return ArticleConverter.toArticleListItemDTO(article, mainImageUuid, isLiked, isSpammed, isMine);
             })

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -163,7 +163,7 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                 // 내 글 여부
                 boolean isMine = memberId.equals(article.getMember().getId());
 
-                log.info("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);
+                log.debug("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);
                 return ArticleConverter.toArticleListItemDTO(article, mainImageUuid, isLiked, isSpammed, isMine);
             })
             .toList();

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -29,6 +29,7 @@ import DNBN.spring.web.dto.ArticleResponseDTO;
 import DNBN.spring.web.dto.response.PostResponseDTO;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -39,6 +40,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+@Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
@@ -131,21 +133,24 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
 
         return articles.stream()
             .map(article -> {
+                Long articleId = article.getArticleId();
+
                 // 대표 이미지
                 String mainImageUuid = articlePhotoRepository.findFirstByArticleAndIsMainTrue(article)
                     .map(ArticlePhoto::getFileKey)
                     .orElseGet(() -> DEFAULT_IMAGE_UUID);
                 // 좋아요 여부
                 boolean isLiked = articleLikeRepository.existsById(
-                    new ArticleLikeId(article.getArticleId(), memberId)
+                    new ArticleLikeId(articleId, memberId)
                 );
                 // 스팸 여부
                 boolean isSpammed = articleSpamRepository.existsById(
-                    new ArticleSpamId(article.getArticleId(), memberId)
+                    new ArticleSpamId(articleId, memberId)
                 );
                 // 내 글 여부
                 boolean isMine = memberId.equals(article.getMember().getId());
 
+                log.info("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);
                 return ArticleConverter.toArticleListItemDTO(article, mainImageUuid, isLiked, isSpammed, isMine);
             })
             .toList();

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -102,12 +102,12 @@ public class ArticleController {
     )
     public ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>> getArticleList(
             @AuthenticationPrincipal MemberDetails memberDetails,
-            Long regionId,
+            Long placeId,
             Long cursor,
             Long limit
     ) {
         Long memberId = memberDetails.getMember().getId();
-        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, regionId, cursor, limit);
+        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
         return ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, articles);
     }
 }

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -93,4 +93,21 @@ public class ArticleController {
         ArticleResponseDTO.ArticleDetailDTO response = articleQueryService.getArticleDetail(articleId);
         return ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, response);
     }
+
+    @GetMapping
+    @Operation(
+        summary = "게시물 목록 조회",
+        description = "게시물 목록을 조회합니다. JWT 인증 필요.",
+        security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>> getArticleList(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            Long regionId,
+            Long cursor,
+            Long limit
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, regionId, cursor, limit);
+        return ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, articles);
+    }
 }

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -20,6 +20,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
@@ -102,9 +103,9 @@ public class ArticleController {
     )
     public ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>> getArticleList(
             @AuthenticationPrincipal MemberDetails memberDetails,
-            Long placeId,
-            Long cursor,
-            Long limit
+            @RequestParam("placeId") Long placeId,
+            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "limit", required = false) Long limit
     ) {
         Long memberId = memberDetails.getMember().getId();
         List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, placeId, cursor, limit);

--- a/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/ArticleResponseDTO.java
@@ -125,4 +125,44 @@ public class ArticleResponseDTO {
             this.updatedAt = updatedAt;
         }
     }
+
+    @Builder
+    @Getter
+    public static class ArticleListItemDTO {
+        private final Long memberId;
+        private final Long articleId;
+        private final Long regionId;
+        private final Long placeId;
+        private final String nickname;
+        private final String title;
+        private final String pinCategory;
+        private final String mainImageUuid;
+        private final Long likeCount;
+        private final Long spamCount;
+        private final Long commentCount;
+        private final Boolean isLiked;
+        private final Boolean isSpammed;
+        private final Boolean isMine;
+        private final String createdAt;
+        private final String updatedAt;
+
+        private ArticleListItemDTO(Long memberId, Long articleId, Long regionId, Long placeId, String nickname, String title, String pinCategory, String mainImageUuid, Long likeCount, Long spamCount, Long commentCount, Boolean isLiked, Boolean isSpammed, Boolean isMine, String createdAt, String updatedAt) {
+            this.memberId = memberId;
+            this.articleId = articleId;
+            this.regionId = regionId;
+            this.placeId = placeId;
+            this.nickname = nickname;
+            this.title = title;
+            this.pinCategory = pinCategory;
+            this.mainImageUuid = mainImageUuid;
+            this.likeCount = likeCount;
+            this.spamCount = spamCount;
+            this.commentCount = commentCount;
+            this.isLiked = isLiked;
+            this.isSpammed = isSpammed;
+            this.isMine = isMine;
+            this.createdAt = createdAt;
+            this.updatedAt = updatedAt;
+        }
+    }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,11 +72,7 @@ spring:
       maxRequestSize: 100MB  # 한 번에 최대 업로드 가능 용량
       # resolve-lazily 옵션 설명:
       # false (기본값): 파일 파싱이 컨트롤러 진입 전에 이뤄짐
-      #   - 파일 크기 초과 등 예외가 Spring의 ExceptionHandler(@ExceptionHandler)에서 처리됨
-      #   - 대부분의 서비스에서 사용하는 일반적인 방식
       # true: 파일 파싱을 컨트롤러 파라미터 바인딩 시점으로 미룸
-      #   - 인증/권한 체크 전에 파일 파싱을 막고 싶을 때 사용(보안 목적)
-      #   - 이 경우 파일 크기 초과 등 예외가 ExceptionHandler까지 도달하지 않고, 더 앞단(서블릿 컨테이너 등)에서 처리됨
       resolve-lazily: false
 server:
   forward-headers-strategy: framework

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -109,3 +109,4 @@ article:
     image:
       max-count: 10
       max-size: 10485760 # 10MB (byte)
+  default-image-uuid: ae383fd6-4211-496b-a631-827954b03306

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
@@ -1,0 +1,373 @@
+package DNBN.spring.service.ArticleService;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
+import DNBN.spring.repository.ArticlePhotoRepository.ArticlePhotoRepository;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.repository.ArticleSpamRepository.ArticleSpamRepository;
+import java.lang.reflect.Field;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import DNBN.spring.domain.*;
+import DNBN.spring.domain.enums.PinCategory;
+import DNBN.spring.web.dto.ArticleResponseDTO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+class ArticleQueryServiceImplTest {
+
+  @Mock
+  private ArticleRepository articleRepository;
+  @Mock
+  private ArticlePhotoRepository articlePhotoRepository;
+  @Mock
+  private ArticleLikeRepository articleLikeRepository;
+  @Mock
+  private ArticleSpamRepository articleSpamRepository;
+  @Mock
+  private DNBN.spring.repository.MemberRepository.MemberRepository memberRepository;
+  @Mock
+  private DNBN.spring.repository.PlaceRepository.PlaceRepository placeRepository;
+  @Mock
+  private DNBN.spring.repository.ArticleRepository.ArticleRepositoryCustom articleRepositoryCustom;
+
+  @InjectMocks
+  private ArticleQueryServiceImpl articleQueryService;
+
+  private static final String DEFAULT_IMAGE_UUID = "ae383fd6-4211-496b-a631-827954b03306";
+
+  @BeforeEach
+  void setUp() {
+    MockitoAnnotations.openMocks(this);
+    // @Value 필드 수동 주입
+    articleQueryService.getClass().getDeclaredFields();
+    try {
+      var field = ArticleQueryServiceImpl.class.getDeclaredField("defaultImageUuid");
+      field.setAccessible(true);
+      field.set(articleQueryService, DEFAULT_IMAGE_UUID);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /*
+    * 일반적인 게시글 조회 검증
+   */
+  @Test
+  void getArticleList_정상_조회() throws NoSuchFieldException, IllegalAccessException {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Long cursor = null;
+    Long limit = 2L;
+
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    Place place = Place.builder().placeId(placeId).title("장소").pinCategory(PinCategory.CAFE).address("주소").build();
+    Article article1 = Article.builder()
+        .articleId(10L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목1")
+        .content("내용1")
+        .likesCount(5L)
+        .spamCount(0L)
+        .commentCount(1L)
+        .date(LocalDate.now())
+        .build();
+    Article article2 = Article.builder()
+        .articleId(9L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목2")
+        .content("내용2")
+        .likesCount(3L)
+        .spamCount(1L)
+        .commentCount(2L)
+        .date(LocalDate.now())
+        .build();
+
+    // createdAt, updatedAt 필드 설정
+    for (Article article : List.of(article1, article2)) {
+      Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+      createdAtField.setAccessible(true);
+      createdAtField.set(article, LocalDateTime.now());
+
+      Field updatedAtField = Article.class.getSuperclass().getDeclaredField("updatedAt");
+      updatedAtField.setAccessible(true);
+      updatedAtField.set(article, LocalDateTime.now());
+    }
+
+    List<Article> articles = List.of(article1, article2);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+
+    // then
+    assertEquals(2, result.size());
+    assertEquals(article1.getArticleId(), result.get(0).getArticleId());
+    assertEquals(article2.getArticleId(), result.get(1).getArticleId());
+    assertEquals(DEFAULT_IMAGE_UUID, result.get(0).getMainImageUuid());
+    assertFalse(result.get(0).getIsLiked());
+    assertFalse(result.get(0).getIsSpammed());
+    assertTrue(result.get(0).getIsMine());
+  }
+
+  /*
+    * 삭제된 게시물은 제외하고 조회되는지 검증
+   */
+  @Test
+  void getArticleList_삭제된_게시물_제외_정상_조회() throws Exception {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Long cursor = null;
+    Long limit = 3L;
+
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    Place place = Place.builder().placeId(placeId).title("장소").pinCategory(PinCategory.CAFE).address("주소").build();
+
+    Article article1 = Article.builder()
+        .articleId(10L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목1")
+        .content("내용1")
+        .likesCount(5L)
+        .spamCount(0L)
+        .commentCount(1L)
+        .date(LocalDate.now())
+        .build();
+
+    Article article2 = Article.builder()
+        .articleId(9L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목2")
+        .content("내용2")
+        .likesCount(3L)
+        .spamCount(1L)
+        .commentCount(2L)
+        .date(LocalDate.now())
+        .build();
+
+    Article deletedArticle = Article.builder()
+        .articleId(8L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("삭제된글")
+        .content("삭제됨")
+        .likesCount(3L)
+        .spamCount(4L)
+        .commentCount(5L)
+        .date(LocalDate.now())
+        .build();
+
+    // deletedAt, createdAt, updatedAt 필드 설정
+    Field deletedAtField = Article.class.getDeclaredField("deletedAt");
+    deletedAtField.setAccessible(true);
+    deletedAtField.set(deletedArticle, LocalDateTime.now());
+
+    for (Article article : List.of(article1, article2, deletedArticle)) {
+      Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+      createdAtField.setAccessible(true);
+      createdAtField.set(article, LocalDateTime.now());
+
+      Field updatedAtField = Article.class.getSuperclass().getDeclaredField("updatedAt");
+      updatedAtField.setAccessible(true);
+      updatedAtField.set(article, LocalDateTime.now());
+    }
+
+    List<Article> articles = List.of(article1, article2);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+
+    // then
+    // 삭제된 게시물은 result에 포함되지 않아야 함
+    assertEquals(2, result.size());
+    assertTrue(result.stream().noneMatch(dto -> dto.getArticleId().equals(deletedArticle.getArticleId())));
+  }
+
+  /*
+    * 좋아요/스팸 처리를 한 게시글일 때, true로 반환되는지 검증
+   */
+  @Test
+  void getArticleList_좋아요_스팸_여부_검증() throws Exception {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Long cursor = null;
+    Long limit = 1L;
+
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    Place place = Place.builder().placeId(placeId).title("장소").pinCategory(PinCategory.CAFE).address("주소").build();
+    Article article = Article.builder()
+        .articleId(10L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목")
+        .content("내용")
+        .likesCount(1L)
+        .spamCount(1L)
+        .commentCount(0L)
+        .date(LocalDate.now())
+        .build();
+
+    Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+    createdAtField.setAccessible(true);
+    createdAtField.set(article, LocalDateTime.now());
+    Field updatedAtField = Article.class.getSuperclass().getDeclaredField("updatedAt");
+    updatedAtField.setAccessible(true);
+    updatedAtField.set(article, LocalDateTime.now());
+
+    List<Article> articles = List.of(article);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(true); // 좋아요 true
+    when(articleSpamRepository.existsById(any())).thenReturn(true); // 스팸 true
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+
+    // then
+    // 좋아요/스팸 여부가 true로 반환되는지 검증
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).getIsLiked());
+    assertTrue(result.get(0).getIsSpammed());
+  }
+
+  /*
+    * limit가 null인 경우, 기본 limit(10)으로 처리되어야 하며 정상적으로 조회되는지 검증
+   */
+  @Test
+  void getArticleList_cursor_limit_null_정상_조회() throws Exception {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Long cursor = null;
+    Long limit = null; // limit null
+
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    Place place = Place.builder().placeId(placeId).title("장소").pinCategory(PinCategory.CAFE).address("주소").build();
+    Article article = Article.builder()
+        .articleId(10L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목")
+        .content("내용")
+        .likesCount(0L)
+        .spamCount(0L)
+        .commentCount(0L)
+        .date(LocalDate.now())
+        .build();
+
+    Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+    createdAtField.setAccessible(true);
+    createdAtField.set(article, LocalDateTime.now());
+    Field updatedAtField = Article.class.getSuperclass().getDeclaredField("updatedAt");
+    updatedAtField.setAccessible(true);
+    updatedAtField.set(article, LocalDateTime.now());
+
+    List<Article> articles = List.of(article);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    // 기본 limit(10) + 1 = 11
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, 11L)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+
+    // then
+    // limit이 null이어도 정상적으로 조회되는지 검증
+    assertEquals(1, result.size());
+    assertEquals(article.getArticleId(), result.get(0).getArticleId());
+  }
+
+  /*
+    * cursor가 -1인 경우, null로 처리되어 정상적으로 조회되는지 검증
+   */
+  @Test
+  void getArticleList_cursor_마이너스1_정상_조회() throws Exception {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Long cursor = -1L;
+    Long limit = 1L;
+
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    Place place = Place.builder().placeId(placeId).title("장소").pinCategory(PinCategory.CAFE).address("주소").build();
+    Article article = Article.builder()
+        .articleId(10L)
+        .member(member)
+        .place(place)
+        .region(Region.builder().id(100L).build())
+        .title("제목")
+        .content("내용")
+        .likesCount(0L)
+        .spamCount(0L)
+        .commentCount(0L)
+        .date(LocalDate.now())
+        .build();
+
+    Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+    createdAtField.setAccessible(true);
+    createdAtField.set(article, LocalDateTime.now());
+    Field updatedAtField = Article.class.getSuperclass().getDeclaredField("updatedAt");
+    updatedAtField.setAccessible(true);
+    updatedAtField.set(article, LocalDateTime.now());
+
+    List<Article> articles = List.of(article);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    // cursor가 -1이면 null로 처리되어야 함
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, null, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+
+    // then
+    // cursor가 -1일 때도 정상적으로 조회되는지 검증
+    assertEquals(1, result.size());
+    assertEquals(article.getArticleId(), result.get(0).getArticleId());
+  }
+}

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
@@ -3,6 +3,8 @@ package DNBN.spring.service.ArticleService;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.MemberHandler;
 import DNBN.spring.repository.ArticleLikeRepository.ArticleLikeRepository;
 import DNBN.spring.repository.ArticlePhotoRepository.ArticlePhotoRepository;
 import DNBN.spring.repository.ArticleRepository.ArticleRepository;
@@ -369,5 +371,39 @@ class ArticleQueryServiceImplTest {
     // cursor가 -1일 때도 정상적으로 조회되는지 검증
     assertEquals(1, result.size());
     assertEquals(article.getArticleId(), result.get(0).getArticleId());
+  }
+
+  /*
+   * Member가 존재하지 않을 때 예외 발생 검증
+   */
+  @Test
+  void getArticleList_멤버없음_예외() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(MemberHandler.class, () -> {
+      articleQueryService.getArticleList(memberId, placeId, null, null);
+    });
+  }
+
+  /*
+   * Place가 존재하지 않을 때 예외 발생 검증
+   */
+  @Test
+  void getArticleList_장소없음_예외() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    Member member = Member.builder().id(memberId).nickname("테스터").build();
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(ArticleHandler.class, () -> {
+      articleQueryService.getArticleList(memberId, placeId, null, null);
+    });
   }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> Cursor Paging으로 게시물의 목록을 조회하는 API 구현

## 🛠️ 작업 상세 내용
- 스크롤 화면이여서, **cursor paging**으로 구현하였습니다.
  - `getArticleList` 에서 limit가 null인 경우, cursor가 -1인 경우를 고려하였습니다.
  - `limit + 1`을 조회하여 `hasNext`를 확인하고, 이후 마지막 데이터는 제거하여 다음 페이지 여부를 확인하였습니다.
- 비즈니스 로직상 메인 이미지는 null이 될 수 없으나, 테스트 데이터에 메인 이미지가 없는 경우가 있어 `Optional`로 반환하게 하였습니다.
- 대표 이미지는 한 개 이상 저장될 수가 없는 구조이긴 하지만, **불필요한 전체 조회(full-scan)을 막기 위해** `findAllByArticle` 대신 `findFirstByArticleAndIsMainTrue`를 사용하였습니다.

## 💬 기타(공유사항 to 리뷰어)
- 기존 테스트 시나리오대로 테스트 코드를 구현해서 테스트는 생략하셔도 될 것 같습니다.
  - 잘 작성되었는지 확신이 안가서 우선 Swagger로도 테스트 해보았습니다..!
- **(정정)** 이전에 언급되었던 `Querydsl`의 보안 문제를 살펴보았는데, 외부 사용자 입력을 직접 동적 조건으로 넣을 때 발생할 수 있는 문제였습니다.
  -  현재 코드들은 외부 입력값을 직접 반영하지 않아 사용해도 괜찮을 것 같습니다.
```java
return queryFactory
            .selectFrom(article)
            .where(builder)
            .orderBy(article.createdAt.desc()) // 직접 필드 사용
            .limit(limit)
            .fetch();
```

## 🧪  테스트 코드
- 정상 게시글 목록 조회
- `placeId`에 해당하는 게시물이 없을 때 빈 리스트 반환
- 삭제된 게시글 제외 조회
- 좋아요/스팸 여부 필드 값 검증
- `limit`가 null인 경우 기본값 동작 검증
- `cursor`가 -1인 경우 정상 동작 검증
- 멤버가 존재하지 않을 때 예외 발생
- 장소가 존재하지 않을 때 예외 발생