### PR TITLE
♻️ [Refactor] 게시물/댓글 검증 로직을 역할에 맞게 통합 및 분리

### DIFF
--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -16,14 +16,6 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class ArticleValidationAspect {
-    @Value("${article.validation.title.min-length}")
-    private int titleMinLength;
-    @Value("${article.validation.title.max-length}")
-    private int titleMaxLength;
-    @Value("${article.validation.content.min-length}")
-    private int contentMinLength;
-    @Value("${article.validation.content.max-length}")
-    private int contentMaxLength;
 
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
     public void validateArticle(JoinPoint joinPoint) {
@@ -35,14 +27,6 @@ public class ArticleValidationAspect {
       if (dto != null && dto.getClass().isRecord()) {
         titleAndContent = extractTitleAndContentFromRecord(dto);
       }
-
-      // title과 content 길이 검증
-      String title = Objects.requireNonNull(titleAndContent).getFirst();
-      String content = titleAndContent.getSecond();
-      validateLength(title, titleMinLength, titleMaxLength,
-          ErrorStatus.ARTICLE_TITLE_NULL_ERROR, ErrorStatus.ARTICLE_TITLE_LENGTH_VALIDATION_ERROR);
-      validateLength(content, contentMinLength, contentMaxLength,
-          ErrorStatus.ARTICLE_CONTENT_NULL_ERROR, ErrorStatus.ARTICLE_CONTENT_LENGTH_VALIDATION_ERROR);
     }
     
     private Object extractDto(Object[] args) {

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -2,6 +2,10 @@ package DNBN.spring.aop;
 
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.PlaceHandler;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.enums.PinCategory;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
 import DNBN.spring.web.dto.ArticleRequestDTO;
 import DNBN.spring.web.dto.ArticleUpdateRequestDTO;
 import DNBN.spring.web.dto.ArticleWithLocationRequestDTO;
@@ -9,6 +13,7 @@ import java.util.Objects;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Component;
@@ -16,19 +21,46 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class ArticleValidationAspect {
+    @Autowired
+    private ArticleRepository articleRepository;
 
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
     public void validateArticle(JoinPoint joinPoint) {
-      Object[] args = joinPoint.getArgs();
-      Object dto = extractDto(args); // null 검증 생략
+        Object[] args = joinPoint.getArgs();
+        Object dto = extractDto(args);
+        Long memberId = extractLongArg(args, 0, "memberId");
+        Long articleId = extractLongArg(args, 1, "articleId");
 
-      Pair<String, String> titleAndContent = null;
-      // DTO가 Record인 경우만 구현 (Article의 request DTO는 모두 Record)
-      if (dto != null && dto.getClass().isRecord()) {
-        titleAndContent = extractTitleAndContentFromRecord(dto);
-      }
+        // PinCategory 검증
+        validatePinCategory(dto);
+
+        // 권한 및 삭제 여부 검증 (수정/삭제 시)
+        if (articleId != null) {
+            Article article = articleRepository.findById(articleId)
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
+            if (!article.getMember().getId().equals(memberId)) {
+                throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
+            }
+            if (article.getDeletedAt() != null) {
+                throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
+            }
+        }
     }
-    
+
+    private void validatePinCategory(Object dto) {
+        if (dto == null) return;
+        try {
+            var pinCategoryMethod = dto.getClass().getMethod("pinCategory");
+            String pinCategory = (String) pinCategoryMethod.invoke(dto);
+            if (pinCategory == null) throw new PlaceHandler(ErrorStatus.PIN_CATEGORY_INVALID);
+            PinCategory.valueOf(pinCategory.toUpperCase());
+        } catch (NoSuchMethodException e) {
+            // pinCategory 필드가 없는 DTO는 무시
+        } catch (Exception e) {
+            throw new PlaceHandler(ErrorStatus.PIN_CATEGORY_INVALID);
+        }
+    }
+
     private Object extractDto(Object[] args) {
         for (Object arg : args) {
             if (arg instanceof ArticleRequestDTO ||
@@ -61,5 +93,11 @@ public class ArticleValidationAspect {
             throw new ArticleHandler(lengthErrorStatus);
         }
     }
-    
+
+    private Long extractLongArg(Object[] args, int idx, String name) {
+        if (args.length > idx && args[idx] instanceof Long value) {
+            return value;
+        }
+        return null;
+    }
 }

--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -6,7 +6,6 @@ import DNBN.spring.domain.Comment;
 import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.web.dto.CommentRequestDTO;
 import DNBN.spring.web.dto.CommentUpdateRequestDTO;
-import java.util.Objects;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Before;
@@ -17,12 +16,8 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class CommentValidationAspect {
-    private final CommentRepository commentRepository;
 
-    @Value("${comment.validation.content.min-length:2}")
-    private int contentMinLength;
-    @Value("${comment.validation.content.max-length:1000}")
-    private int contentMaxLength;
+    private final CommentRepository commentRepository;
 
     public CommentValidationAspect(CommentRepository commentRepository) {
         this.commentRepository = commentRepository;
@@ -35,9 +30,8 @@ public class CommentValidationAspect {
         Long commentId = extractLongArg(args, 1, "commentId");
         Long articleId = extractLongArg(args, 2, "articleId");
         Comment comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+            .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
         validateCommentOwnership(comment, memberId, articleId);
-        validateCommentContent(args);
     }
 
     private Long extractLongArg(Object[] args, int idx, String name) {
@@ -59,14 +53,6 @@ public class CommentValidationAspect {
         }
     }
 
-    private void validateCommentContent(Object[] args) {
-        Object dto = extractDto(args);
-        Pair<String, String> contentPair = extractContentFromDto(dto);
-        String content = contentPair.getFirst();
-        validateLength(content, contentMinLength, contentMaxLength,
-                ErrorStatus.COMMENT_CONTENT_NULL_ERROR, ErrorStatus.COMMENT_CONTENT_LENGTH_INVALID);
-    }
-
     private Object extractDto(Object[] args) {
         for (Object arg : args) {
             if (arg instanceof CommentRequestDTO || arg instanceof CommentUpdateRequestDTO) {
@@ -86,15 +72,6 @@ public class CommentValidationAspect {
             return Pair.of(content, null);
         } catch (Exception e) {
             throw new IllegalArgumentException("❌ CommentValidationAspect: DTO에서 content 추출 실패", e);
-        }
-    }
-
-    private void validateLength(String value, int min, int max, ErrorStatus nullErrorStatus, ErrorStatus lengthErrorStatus) {
-        if (value == null) {
-            throw new CommentHandler(nullErrorStatus);
-        }
-        if (value.length() < min || value.length() > max) {
-            throw new CommentHandler(lengthErrorStatus);
         }
     }
 }

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -31,6 +31,8 @@ public enum ErrorStatus implements BaseErrorCode {
     ARTICLE_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "ARTICLE4003", "내용은 10~5000자여야 합니다."),
     ARTICLE_FORBIDDEN(HttpStatus.FORBIDDEN, "ARTICLE4004", "해당 게시글에 대한 권한이 없습니다."),
     ARTICLE_ALREADY_DELETED(HttpStatus.CONFLICT, "ARTICLE4005", "이미 삭제된 게시글입니다."),
+    ARTICLE_TITLE_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4006", "제목이 비어 있습니다."),
+    ARTICLE_CONTENT_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4007", "내용이 비어 있습니다."),
 
     // articlePhoto & S3
     ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "ARTICLEPHOTO4002", "대표 이미지는 필수입니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -25,14 +25,12 @@ public enum ErrorStatus implements BaseErrorCode {
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4006", "이미지 형식의 파일만 업로드할 수 있습니다."),
     IMAGE_FILE_TOO_LARGE(HttpStatus.BAD_REQUEST, "IMAGE4007", "이미지 파일은 10MB 이하로 업로드해주세요."),
     
-    // 게시물
+    // article
     ARTICLE_NOT_FOUND(HttpStatus.NOT_FOUND, "ARTICLE4001", "게시글이 없습니다."),
-    ARTICLE_TITLE_LENGTH_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4002", "제목은 2~100자여야 합니다."),
-    ARTICLE_CONTENT_LENGTH_VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4003", "내용은 10~5000자여야 합니다."),
+    ARTICLE_TITLE_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "ARTICLE4002", "제목은 2~100자여야 합니다."),
+    ARTICLE_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "ARTICLE4003", "내용은 10~5000자여야 합니다."),
     ARTICLE_FORBIDDEN(HttpStatus.FORBIDDEN, "ARTICLE4004", "해당 게시글에 대한 권한이 없습니다."),
     ARTICLE_ALREADY_DELETED(HttpStatus.CONFLICT, "ARTICLE4005", "이미 삭제된 게시글입니다."),
-    ARTICLE_TITLE_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4006", "제목은 필수입니다."),
-    ARTICLE_CONTENT_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4007", "내용은 필수입니다."),
 
     // articlePhoto & S3
     ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "ARTICLEPHOTO4002", "대표 이미지는 필수입니다."),
@@ -88,6 +86,7 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "COMMENT4002", "댓글 내용은 1~1000자여야 합니다."),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT4003", "해당 댓글에 대한 권한이 없습니다."),
     COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT, "COMMENT4004", "이미 삭제된 댓글입니다."),
+    COMMENT_TITLE_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "COMMENT4006", "댓글 제목은 2~100자여야 합니다."),
 
     // 챌린지
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE_4001", "챌린지가 존재하지 않습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -88,7 +88,6 @@ public enum ErrorStatus implements BaseErrorCode {
     COMMENT_CONTENT_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "COMMENT4002", "댓글 내용은 1~1000자여야 합니다."),
     COMMENT_FORBIDDEN(HttpStatus.FORBIDDEN, "COMMENT4003", "해당 댓글에 대한 권한이 없습니다."),
     COMMENT_ALREADY_DELETED(HttpStatus.CONFLICT, "COMMENT4004", "이미 삭제된 댓글입니다."),
-    COMMENT_TITLE_LENGTH_INVALID(HttpStatus.BAD_REQUEST, "COMMENT4006", "댓글 제목은 2~100자여야 합니다."),
 
     // 챌린지
     CHALLENGE_NOT_FOUND(HttpStatus.NOT_FOUND, "CHALLENGE_4001", "챌린지가 존재하지 않습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -37,7 +37,6 @@ public enum SuccessStatus implements BaseCode {
 
     // 게시물 관련 응답
     ARTICLE_CREATE_SUCCESS(HttpStatus.CREATED, "ARTICLE_CREATE_SUCCESS", "게시물이 정상적으로 작성되었습니다."),
-
     ARTICLE_READ_SUCCESS(HttpStatus.OK, "ARTICLE_READ_SUCCESS", "게시물 상세페이지가 정상적으로 조회되었습니다."),
     ARTICLE_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "ARTICLE_DELETE_SUCCESS", "게시물이 정상적으로 삭제되었습니다."),
     ARTICLE_UPDATE_SUCCESS(HttpStatus.OK, "ARTICLE_UPDATE_SUCCESS", "게시물이 정상적으로 수정되었습니다.")

--- a/src/main/java/DNBN/spring/domain/Comment.java
+++ b/src/main/java/DNBN/spring/domain/Comment.java
@@ -56,11 +56,18 @@ public class Comment extends BaseEntity {
 
   private LocalDateTime deletedAt;
 
+  @Column(nullable = false)
+  private int depth;
+
   public void delete() {
     this.deletedAt = java.time.LocalDateTime.now();
   }
 
   public void updateContent(String content) {
     this.content = content;
+  }
+
+  public void setDepth(int depth) {
+    this.depth = depth;
   }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -240,9 +240,11 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     // TODO: 책임 분리
     private void updateArticleEntity(Article article, ArticleUpdateRequestDTO request) {
         if (request.title() != null) {
+            titleLengthValidator.validateArticleTitle(request.title());
             article.setTitle(request.title());
         }
         if (request.content() != null) {
+            contentLengthValidator.validateArticleContent(request.content());
             article.setContent(request.content());
         }
         if (request.date() != null) {

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -54,10 +54,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         if (request.parentCommentId() != null) {
             parentComment = commentRepository.findById(request.parentCommentId())
                     .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
-
-            if (!parentComment.getArticle().getArticleId().equals(articleId)) {
-                throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
-            }
+            // parentComment의 articleId 일치 검증은 Aspect에서 처리
         }
         Comment comment = Comment.builder()
                 .article(article)

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -13,6 +13,8 @@ import DNBN.spring.repository.ArticleRepository.ArticleRepository;
 import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
 import DNBN.spring.repository.NotificationRepository.NotificationRepository;
+import DNBN.spring.validation.ContentLengthValidator;
+import DNBN.spring.validation.TitleLengthValidator;
 import DNBN.spring.web.dto.CommentRequestDTO;
 import DNBN.spring.web.dto.CommentResponseDTO;
 import DNBN.spring.web.dto.CommentUpdateRequestDTO;
@@ -27,6 +29,8 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final ArticleRepository articleRepository;
     private final CommentRepository commentRepository;
     private final NotificationRepository notificationRepository;
+    private final ContentLengthValidator contentLengthValidator;
+    private final TitleLengthValidator titleLengthValidator;
 
     private static final int CONTENT_MIN_LENGTH = 2;
     private static final int CONTENT_MAX_LENGTH = 1000;
@@ -39,15 +43,12 @@ public class CommentCommandServiceImpl implements CommentCommandService {
 
     @Override
     public CommentResponseDTO createComment(Long memberId, Long articleId, CommentRequestDTO request) {
-
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new ArticleHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-        if (request.content() == null || request.content().length() < CONTENT_MIN_LENGTH || request.content().length() > CONTENT_MAX_LENGTH) {
-            throw new CommentHandler(ErrorStatus.COMMENT_CONTENT_LENGTH_INVALID);
-        }
+        contentLengthValidator.validateCommentContent(request.content());
 
         Comment parentComment = null;
         if (request.parentCommentId() != null) {
@@ -98,6 +99,9 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     public CommentResponseDTO updateComment(Long memberId, Long commentId, Long articleId, CommentUpdateRequestDTO request) {
         Comment comment = commentRepository.findById(commentId)
             .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+
+        contentLengthValidator.validateCommentContent(request.content());
+
         comment.updateContent(request.content());
         return CommentConverter.toCommentResponseDTO(comment);
     }

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -19,6 +19,7 @@ import DNBN.spring.web.dto.CommentRequestDTO;
 import DNBN.spring.web.dto.CommentResponseDTO;
 import DNBN.spring.web.dto.CommentUpdateRequestDTO;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -31,6 +32,9 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final NotificationRepository notificationRepository;
     private final ContentLengthValidator contentLengthValidator;
     private final MemberRepository memberRepository;
+
+    @Value("${article.comment.validation.max-depth:1}")
+    private int maxCommentDepth;
 
     private Comment getCommentOrThrow(Long commentId) {
         return commentRepository.findById(commentId)
@@ -51,7 +55,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         if (request.parentCommentId() != null) {
             parentComment = commentRepository.findById(request.parentCommentId())
                     .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
-            if (parentComment.getDepth() >= 1) {
+            if (parentComment.getDepth() >= maxCommentDepth) {
                 throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
             }
             depth = parentComment.getDepth() + 1;

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -30,10 +30,6 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     private final CommentRepository commentRepository;
     private final NotificationRepository notificationRepository;
     private final ContentLengthValidator contentLengthValidator;
-    private final TitleLengthValidator titleLengthValidator;
-
-    private static final int CONTENT_MIN_LENGTH = 2;
-    private static final int CONTENT_MAX_LENGTH = 1000;
     private final MemberRepository memberRepository;
 
     private Comment getCommentOrThrow(Long commentId) {

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -47,16 +47,21 @@ public class CommentCommandServiceImpl implements CommentCommandService {
         contentLengthValidator.validateCommentContent(request.content());
 
         Comment parentComment = null;
+        int depth = 0;
         if (request.parentCommentId() != null) {
             parentComment = commentRepository.findById(request.parentCommentId())
                     .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
-            // parentComment의 articleId 일치 검증은 Aspect에서 처리
+            if (parentComment.getDepth() >= 1) {
+                throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
+            }
+            depth = parentComment.getDepth() + 1;
         }
         Comment comment = Comment.builder()
                 .article(article)
                 .member(member)
                 .content(request.content())
                 .parentComment(parentComment)
+                .depth(depth)
                 .build();
 
         commentRepository.save(comment);

--- a/src/main/java/DNBN/spring/validation/ContentLengthValidator.java
+++ b/src/main/java/DNBN/spring/validation/ContentLengthValidator.java
@@ -1,0 +1,42 @@
+package DNBN.spring.validation;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.CommentHandler;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+// TODO: request DTO가 record여서, Service에서 직접 ContentLengthValidator를 호출해야 함.
+@Getter
+@Component
+public class ContentLengthValidator {
+    @Value("${article.validation.content.min-length}")
+    private int articleContentMinLength;
+    @Value("${article.validation.content.max-length}")
+    private int articleContentMaxLength;
+    @Value("${article.comment.validation.content.min-length}")
+    private int commentContentMinLength;
+    @Value("${article.comment.validation.content.max-length}")
+    private int commentContentMaxLength;
+
+    public boolean isValidArticleContent(String content) {
+        return content != null && content.length() >= articleContentMinLength && content.length() <= articleContentMaxLength;
+    }
+
+    public boolean isValidCommentContent(String content) {
+        return content != null && content.length() >= commentContentMinLength && content.length() <= commentContentMaxLength;
+    }
+
+    public void validateArticleContent(String content) {
+        if (!isValidArticleContent(content)) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_CONTENT_LENGTH_INVALID);
+        }
+    }
+
+    public void validateCommentContent(String content) {
+        if (!isValidCommentContent(content)) {
+            throw new CommentHandler(ErrorStatus.COMMENT_CONTENT_LENGTH_INVALID);
+        }
+    }
+}

--- a/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
+++ b/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
@@ -1,6 +1,7 @@
 package DNBN.spring.validation;
 
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
 import DNBN.spring.apiPayload.exception.handler.CommentHandler;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
@@ -18,9 +19,9 @@ public class TitleLengthValidator {
         return title != null && title.length() >= articleTitleMinLength && title.length() <= articleTitleMaxLength;
     }
 
-    public void validateCommentTitle(String title) {
-        if (title == null || title.length() < 2 || title.length() > 100) {
-            throw new CommentHandler(ErrorStatus.COMMENT_TITLE_LENGTH_INVALID);
+    public void validateArticleTitle(String content) {
+        if (!isValidArticleTitle(content)) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_TITLE_LENGTH_INVALID);
         }
     }
 }

--- a/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
+++ b/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
@@ -1,0 +1,26 @@
+package DNBN.spring.validation;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.CommentHandler;
+import lombok.Getter;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Component
+public class TitleLengthValidator {
+    @Value("${article.validation.title.min-length}")
+    private int articleTitleMinLength;
+    @Value("${article.validation.title.max-length}")
+    private int articleTitleMaxLength;
+
+    public boolean isValidArticleTitle(String title) {
+        return title != null && title.length() >= articleTitleMinLength && title.length() <= articleTitleMaxLength;
+    }
+
+    public void validateCommentTitle(String title) {
+        if (title == null || title.length() < 2 || title.length() > 100) {
+            throw new CommentHandler(ErrorStatus.COMMENT_TITLE_LENGTH_INVALID);
+        }
+    }
+}

--- a/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
+++ b/src/main/java/DNBN/spring/validation/TitleLengthValidator.java
@@ -2,7 +2,6 @@ package DNBN.spring.validation;
 
 import DNBN.spring.apiPayload.code.status.ErrorStatus;
 import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
-import DNBN.spring.apiPayload.exception.handler.CommentHandler;
 import lombok.Getter;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -115,3 +115,4 @@ article:
       content:
         min-length: 2
         max-length: 1000
+      max-depth: 1


### PR DESCRIPTION
## #️⃣ 기능 설명
> Article/Comment의 검증 로직을 Aspect와 Validator로 역할에 맞게 통합 및 분리
Article/Comment 관련 모든 검증 로직을 일관성 있게 관리하고, 서비스가 비즈니스 로직에 집중할 수 있도록 개선

## 🛠️ 작업 상세 내용
- [x] Article/Comment ServiceImpl에서 검증 로직 제거
- [x] 단순 값 검증(길이, null) Validator로 분리 및 적용
- [x] 권한/삭제 여부 등 비즈니스 규칙 검증 Aspect로 분리 및 적용
- [x] 기존에 작성한 테스트 시나리오 및 예외 처리 기반으로 검증 누락 확인
  - [x] 게시글 생성
  - [x] 게시글 수정
  - [x] 게시글 삭제
  - [x] 댓글 생성
  - [x] 댓글 수정
  - [x] 댓글 삭제
- 댓글 엔티티에 `depth` 필드 추가 및 대댓글 깊이 제한(1단계) 검증 로직 구현
  - 확장성을 고려해 `depth`를 `parentComment.getDepth() + 1`로 할당
  - 댓글 최대 `depth`를 `application.yml` 변수로 분리

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 기존에 `Aspect`로 검증을 분리하였으나, `ServiceImpl`에 검증 로직이 남아있어 이번 이슈를 통해 게시물과 댓글 검증을 모두 책임에 맞게 분리하려고 하였습니다.
- 단순 값 검증(길이, null)은 `Validator`에서 분리하여, `ServiceImpl`에서 호출하여 검증하였습니다
  - request DTO를 record 타입으로 유지해 불변성을 명시하고 싶어, class 전환 및 `@Size` 어노테이션 사용을 반려하였습니다.
- 비즈니스 규칙 검증(권한, 삭제여부)은 `Aspect`로 분리하였습니다.
- 댓글 생성 시 대댓글의 깊이 제한을 검증하고, `depth` 필드로 확장성을 고려하였습니다.

## ✏️ 추후 개선 필요한 부분 (선택)
- 이미지 업로드 관련 검증 개선 및 확대 (생성/수정/삭제 시 롤백 등)
