### PR TITLE
♻️ [Refactor] HikariCP 커넥션 풀 설정 최적화

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -4,6 +4,15 @@ spring:
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
     driver-class-name: com.mysql.cj.jdbc.Driver
+    hikari:
+      pool-name: app-hikari
+      maximum-pool-size: 20          # CPU/부하/DB 여건에 따라 10~30부터 시작
+      minimum-idle: 5
+      connection-timeout: 30000      # 밀리초, 풀에서 빌리는 대기 최대시간
+      idle-timeout: 600000           # 10분, 놀고있는 커넥션 정리
+      max-lifetime: 1700000          # 28m20s, DB wait_timeout보다 1~2분 짧게
+      validation-timeout: 5000
+      leak-detection-threshold: 20000   # 20초 넘게 반납 안 하면 로그로 경고(원인 추적용)
   sql:
     init:
       mode: never
@@ -32,7 +41,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URL}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao


### PR DESCRIPTION
## #️⃣ 기능 설명
> MySQL Too many connections 오류 방지를 위한 커넥션 풀 설정 최적화.
이전에 max_connections 값을 120에서 150으로 증가시켰으나
근본적인 해결을 위해 HikariCP 설정 파라미터 조정

## 📊 진단 과정
<img width="1867" height="1352" alt="Image" src="https://github.com/user-attachments/assets/13bcc30d-7dae-4d0e-a4fd-b3cc2e857411" />

### 2. HikariCP 설정:
- 300초 이상 초과하는 세션 조회 → 50개 이상 조회됨
<img width="627" height="112" alt="Image" src="https://github.com/user-attachments/assets/ae05c6d2-044b-45d6-a6e1-84da65b6349e" />

- DB가 먼저 커넥션을 끊는 상황을 방지하기 위해, `wait_timeout` 시간을 고려해 `maxLifetime`을 1700초로 조정하였습니다.

```yaml
hikari:
  pool-name: app-hikari
  maximum-pool-size: 20          
  minimum-idle: 5
  connection-timeout: 30000      
  idle-timeout: 600000           
  max-lifetime: 1700000          
  validation-timeout: 5000
  leak-detection-threshold: 20000
```

### 3. 조치 후 슬립 상태 세션 조사:
50개 이상 → 24 행으로 감소
<img width="1881" height="1297" alt="Image" src="https://github.com/user-attachments/assets/dfd944f6-072e-4624-a23f-854ad9b82bf0" />

## ✏️ 추후 개선 필요한 부분 (선택)
- 모니터링 필요
- Sleep 세션이 많아지는 이유 파악