### PR TITLE
♻️ [Refactor] sameSite를 None으로 수정

### DIFF
--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -116,7 +116,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .path("/")
                 .domain("dnbn.site")
                 .maxAge(0)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         // refreshToken 쿠키 삭제 (즉시 만료 설정)
@@ -126,7 +126,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .path("/")
                 .domain("dnbn.site") // 운영 도메인과 맞춰서 설정
                 .maxAge(0) // 즉시 만료
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         // CSRF 토큰 쿠키 삭제
@@ -136,7 +136,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .path("/")
                 .domain("dnbn.site") // 테스트 시 주석처리
                 .maxAge(0)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", deleteAccessTokenCookie.toString());

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2FailureHandler.java
@@ -57,7 +57,7 @@ public class OAuth2FailureHandler implements AuthenticationFailureHandler {
                 .path("/")
                 .domain("dnbn.site")
                 .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -112,7 +112,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .path("/")
                 .domain("dnbn.site") // 로컬 테스트 시 주석 처리해야 함
                 .maxAge(60 * 60 * 4)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", csrfCookie.toString());
@@ -128,7 +128,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
                 .path("/")
                 .domain("dnbn.site")
                 .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -68,7 +68,7 @@ public class AuthRestController {
                 .path("/")
                 .domain("dnbn.site") // 테스트 시 주석처리
                 .maxAge(60 * 60 * 4) // 4시간
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
         response.addHeader("Set-Cookie", csrfCookie.toString());
 
@@ -87,7 +87,7 @@ public class AuthRestController {
                 .path("/")
                 .domain("dnbn.site")
                 .maxAge(maxAgeInSeconds)
-                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -41,7 +41,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: ${KAKAO_REDIRECT_URL}
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao


### PR DESCRIPTION
## #️⃣ 기능 설명
> 상동

## 🛠️ 작업 상세 내용
- [x] 성공/실패 핸들러, 로그아웃, 토큰 재발급의 Lax값을 None으로 수정

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
