### PR TITLE
✨ [Feat] Spring Actuator 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,10 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+
+	// actuator
+	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+	implementation 'io.micrometer:micrometer-core'
 }
 
 tasks.named('test') {

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
                         (requests) -> requests
                                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                                 .requestMatchers("/", "/api/auth/reissue", "/swagger-ui/**", "/v3/api-docs/**").permitAll()
+                                .requestMatchers("/actuator/**").hasRole("ADMIN")
 //                                .requestMatchers("/admin/**").hasRole("ADMIN") // pm이 ADMIN역할 기능 필요 X
                                 .anyRequest().authenticated()
                 )

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,14 @@
+management:
+  endpoints:
+    web:
+      exposure:
+        include:
+          - health
+          - info
+          - metrics
+          - prometheus
+  endpoint:
+    metrics:
+      enabled: true
+    prometheus:
+      enabled: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,6 @@
 spring:
+  profiles:
+    active: prod
   datasource:
     url: ${DB_URL}
     username: ${DB_USERNAME}


### PR DESCRIPTION
## #️⃣ 기능 설명
> 운영 환경에서도 HikariCP 커넥션 풀, JVM 메모리, HTTP 요청 수 등  
애플리케이션 내부 지표를 수집할 수 있도록 Spring Actuator 설정을 추가하였습니다.

## ⚙️ 설정 배경
- 커넥션 풀 누수/병목 이슈 대응
- 추후 외부 모니터링 시스템 연동을 위한 기반 작업

## 📈 확인 가능한 주요 지표
- `hikaricp.connections.active` (사용 중인 커넥션 수)
- `hikaricp.connections.pending` (대기 중 요청 수)
- `hikaricp.connections.timeout` (커넥션 실패 수)
- `http.server.requests` (API 요청 수)
- `jvm.memory.used` (JVM 메모리 사용량)
- `spring.security.filterchains.*` (보안 필터 체인 통계)

## 🌱 참고 사항
- 운영 환경 모니터링을 위한 내부 설정
- `ADMIN`으로 권한 설정