### PR TITLE
🛠️ [Test] Spring Security 표준에 부합하는 CSRF 토큰 관리 방식으로 수정

### DIFF
--- a/src/main/java/DNBN/spring/config/security/CsrfCookieConfig.java
+++ b/src/main/java/DNBN/spring/config/security/CsrfCookieConfig.java
@@ -1,0 +1,25 @@
+package DNBN.spring.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+
+@Configuration
+public class CsrfCookieConfig {
+    @Bean
+    public CookieCsrfTokenRepository csrfTokenRepository() {
+        CookieCsrfTokenRepository repository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+
+        // setCookieCustomizer로 쿠키 속성 세밀하게 지정
+        repository.setCookieCustomizer(builder ->
+                builder
+                        .httpOnly(false) // CSRF 쿠키는 JS에서 읽을 수 있도록 false
+                        .secure(true) // HTTPS 환경에서 true
+                        .path("/")
+                        .domain("dnbn.site")
+                        .maxAge(60 * 60 * 4) // 4시간
+                        .sameSite("None")
+        );
+        return repository;
+    }
+}

--- a/src/main/java/DNBN/spring/config/security/SecurityConfig.java
+++ b/src/main/java/DNBN/spring/config/security/SecurityConfig.java
@@ -40,6 +40,7 @@ public class SecurityConfig {
     private final OAuth2FailureHandler oAuth2FailureHandler;
     private final CustomAuthenticationEntryPoint customAuthenticationEntryPoint;
     private final CustomAccessDeniedHandler customAccessDeniedHandler;
+    private final CookieCsrfTokenRepository csrfTokenRepository;
 
     @Bean
     CorsConfigurationSource corsConfigurationSource() { // CORS 설정
@@ -84,7 +85,8 @@ public class SecurityConfig {
 //                .disable()
 //                .csrf(AbstractHttpConfigurer::disable)
                 .csrf(csrf -> csrf
-                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
+//                        .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse()) // CSRF 토큰을 일반 쿠키(HttpOnly=false)에 저장하여 JS가 읽을 수 있게 하는 설정
+                        .csrfTokenRepository(csrfTokenRepository)
                         .ignoringRequestMatchers("/api/auth/**") // GET은 자동으로 제외됨
                 )
                 .oauth2Login(oauth2 -> oauth2

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -33,6 +33,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final ObjectMapper objectMapper;
+    private final CookieCsrfTokenRepository csrfTokenRepository;
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
@@ -99,15 +100,13 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         addCookie(response, "code", status.getCode(), false, 60);
         addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
 
-        // 3. CSRF 토큰 수동 발급 + 쿠키로 내려주기
+        // 3. CSRF 토큰 발급 + 쿠키로 내려주기
 //        CsrfTokenRepository csrfTokenRepository = new HttpSessionCsrfTokenRepository();
-        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+//        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
         CsrfToken csrfToken = csrfTokenRepository.generateToken(request);
-//        csrfTokenRepository.saveToken(csrfToken, request, response);
+        csrfTokenRepository.saveToken(csrfToken, request, response);
         request.setAttribute(CsrfToken.class.getName(), csrfToken);
         request.setAttribute(csrfToken.getParameterName(), csrfToken);
-
-        addCookie(response, "XSRF-TOKEN", csrfToken.getToken(), false, 60 * 60 * 4);
 
         // 프론트에서 JS로 읽을 수 있게 HttpOnly = false
 //        ResponseCookie csrfCookie = ResponseCookie.from("XSRF-TOKEN", csrfToken.getToken())
@@ -120,6 +119,8 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 //                .build();
 
 //        response.addHeader("Set-Cookie", csrfCookie.toString());
+
+//        addCookie(response, "XSRF-TOKEN", csrfToken.getToken(), false, 60 * 60 * 4);
 
         // 4. 리다이렉트 (브릿지 페이지)
         response.sendRedirect("https://www.dnbn.site/oauth-redirect");

--- a/src/main/java/DNBN/spring/web/controller/AuthRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/AuthRestController.java
@@ -31,6 +31,7 @@ public class AuthRestController {
     private final MemberCommandService memberCommandService;
     private final AuthCommandService authCommandService;
     private final JwtTokenProvider jwtTokenProvider;
+    private final CookieCsrfTokenRepository csrfTokenRepository;
 
     @PostMapping("/logout")
     @Operation(summary = "회원 로그아웃 API - JWT AccessToken 인증 필요, CSRF 인증은 요구되지 않습니다.",
@@ -63,11 +64,13 @@ public class AuthRestController {
 
         // csrf 토큰 재발급
 //        CsrfToken csrfToken = authCommandService.generateCsrfToken(request, response);addCookie(response, "XSRF-TOKEN", csrfToken.getToken(), false, 60 * 60 * 4);
-        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
+//        CookieCsrfTokenRepository csrfTokenRepository = CookieCsrfTokenRepository.withHttpOnlyFalse();
         CsrfToken csrfToken = csrfTokenRepository.generateToken(request);
+        csrfTokenRepository.saveToken(csrfToken, request, response);
+
         request.setAttribute(CsrfToken.class.getName(), csrfToken);
         request.setAttribute(csrfToken.getParameterName(), csrfToken);
-        addCookie(response, "XSRF-TOKEN", csrfToken.getToken(), false, 60 * 60 * 4);
+//        addCookie(response, "XSRF-TOKEN", csrfToken.getToken(), false, 60 * 60 * 4);
 
         // 응답 바디 없이 204 No Content
         response.setStatus(HttpServletResponse.SC_NO_CONTENT);


### PR DESCRIPTION
## #️⃣ 기능 설명
> 기존보다 스프링 시큐리티 표준에 부합하는 방식으로 수정

## 🛠️ 작업 상세 내용
- [x] CsrfCookieConfig 추가 후 여기를 통해서 csrf 생성하도록
- [x] 시큐리티 컨피그에 CsrfCookieConfig의 레포 등록
- [x] 성공핸들러와 토큰 재발급에서 CsrfCookieConfig를 사용하도록

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
