### PR TITLE
🔨 [Fix] SuccessStatus에 MEMBER_ALREADY_ONBOARDING_COMPLETED 상수 누락 복구

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -23,6 +23,7 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_NICKNAME_UPDATE_SUCCESS(HttpStatus.OK, "MEMBER2008", "닉네임이 성공적으로 변경되었습니다."),
     MEMBER_REGION_UPDATE_SUCCESS(HttpStatus.OK, "MEMBER2009", "관심 동네가 성공적으로 변경되었습니다."),
     MEMBER_PROFILE_IMAGE_UPDATE_SUCCESS(HttpStatus.OK, "MEMBER2010", "프로필 이미지가 성공적으로 변경되었습니다."),
+    MEMBER_ALREADY_ONBOARDING_COMPLETED(HttpStatus.OK, "MEMBER2011", "온보딩이 이미 완료된 유저입니다."),
 
     // 장소 저장 관련 응답
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.CREATED, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),


### PR DESCRIPTION
- 온보딩 완료 상태 응답 코드 누락으로 인한 배포 실패 및 서버 장애 해결

## #️⃣ 기능 설명
> 추가하려는 기능에 대해 간결하게 설명해주세요

## 🛠️ 작업 상세 내용
- [ ] TODO
- [ ] TODO
- [ ] TODO

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
