### PR TITLE
🚀  [Perf] 게시글 목록 API V2 추가 (복합 커서 페이징 적용)

### DIFF
--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
@@ -8,5 +8,9 @@ import java.util.List;
 public interface ArticleRepositoryCustom {
     List<Article> findArticlesByCategoryWithCursor(Long categoryId, Long cursor, Long limit);
 
-    List<Article> findArticlesByPlaceWithCursor(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
+    // V1: 단일 커서(Long) 방식
+    List<Article> findArticlesByPlaceWithCursorV1(Long placeId, Long cursor, Long limit);
+
+    // V2
+    List<Article> findArticlesByPlaceWithCursorV2(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryCustom.java
@@ -2,10 +2,11 @@ package DNBN.spring.repository.ArticleRepository;
 
 import DNBN.spring.domain.Article;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ArticleRepositoryCustom {
     List<Article> findArticlesByCategoryWithCursor(Long categoryId, Long cursor, Long limit);
 
-    List<Article> findArticlesByPlaceWithCursor(Long placeId, Long cursor, Long limit);
+    List<Article> findArticlesByPlaceWithCursor(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
 }

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
@@ -36,8 +36,30 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
                 .fetch();
     }
 
+    // V1: 단일 커서(Long) 방식
     @Override
-    public List<Article> findArticlesByPlaceWithCursor(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
+    public List<Article> findArticlesByPlaceWithCursorV1(Long placeId, Long cursor, Long limit) {
+      QArticle article = QArticle.article;
+
+      BooleanBuilder builder = new BooleanBuilder();
+      builder.and(article.place.placeId.eq(placeId));
+      builder.and(article.deletedAt.isNull());
+
+      if (cursor != null) {
+        builder.and(article.articleId.lt(cursor));
+      }
+
+      return queryFactory
+          .selectFrom(article)
+          .where(builder)
+          .orderBy(article.createdAt.desc()) // 정적 필드로 정렬 (SQL Injection 위험 없음)
+          .limit(limit)
+          .fetch();
+    }
+
+    // V2
+    @Override
+    public List<Article> findArticlesByPlaceWithCursorV2(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
         QArticle article = QArticle.article;
 
         BooleanBuilder builder = new BooleanBuilder();

--- a/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/ArticleRepository/ArticleRepositoryImpl.java
@@ -7,6 +7,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -36,21 +37,24 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
     }
 
     @Override
-    public List<Article> findArticlesByPlaceWithCursor(Long placeId, Long cursor, Long limit) {
+    public List<Article> findArticlesByPlaceWithCursor(Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
         QArticle article = QArticle.article;
 
         BooleanBuilder builder = new BooleanBuilder();
         builder.and(article.place.placeId.eq(placeId));
         builder.and(article.deletedAt.isNull());
 
-        if (cursor != null) {
-            builder.and(article.articleId.lt(cursor));
+        if (cursorCreatedAt != null && cursorArticleId != null) {
+            builder.and(
+                article.createdAt.lt(cursorCreatedAt)
+                .or(article.createdAt.eq(cursorCreatedAt).and(article.articleId.lt(cursorArticleId)))
+            );
         }
 
         return queryFactory
             .selectFrom(article)
             .where(builder)
-            .orderBy(article.createdAt.desc()) // 정적 필드로 정렬 (SQL Injection 위험 없음)
+            .orderBy(article.createdAt.desc(), article.articleId.desc())
             .limit(limit)
             .fetch();
     }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
@@ -17,5 +17,9 @@ public interface ArticleQueryService {
 
     ArticleResponseDTO.ArticleDetailDTO getArticleDetail(Long articleId);
 
-    List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
+    // V1: 단일 커서(Long) 방식
+    List<ArticleResponseDTO.ArticleListItemDTO> getArticleListV1(Long memberId, Long regionId, Long cursor, Long limit);
+
+    // V2: 복합 커서(LocalDateTime, Long) 방식
+    List<ArticleResponseDTO.ArticleListItemDTO> getArticleListV2(Long memberId, Long placeId, java.time.LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryService.java
@@ -3,6 +3,7 @@ package DNBN.spring.service.ArticleService;
 import DNBN.spring.domain.Article;
 import DNBN.spring.web.dto.response.ArticleResponseDTO;
 import DNBN.spring.web.dto.response.PostResponseDTO;
+import java.time.LocalDateTime;
 import org.springframework.data.domain.Page;
 
 import java.util.List;
@@ -16,5 +17,5 @@ public interface ArticleQueryService {
 
     ArticleResponseDTO.ArticleDetailDTO getArticleDetail(Long articleId);
 
-    List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long regionId, Long cursor, Long limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit);
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -25,6 +25,7 @@ import DNBN.spring.web.dto.response.ArticleResponseDTO;
 
 import DNBN.spring.web.dto.response.PostResponseDTO;
 
+import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -36,7 +37,6 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -134,19 +134,60 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
         return ArticleConverter.toArticleDetailDTO(article, photos);
     }
 
+    // V1: 단일 커서(Long) 방식
     @Override
-    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
-        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT;
+    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleListV1(Long memberId, Long placeId, Long cursor, Long limit) {
+        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT; // limit가 null인 경우 기본값 설정
+
+        if (cursor == null || cursor == -1L) {
+            cursor = null;
+        }
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Place place = placeRepository.findPlaceByPlaceId(placeId)
             .orElseThrow(() -> new ArticleHandler(ErrorStatus.PLACE_NOT_FOUND));
         
-        List<Article> articles = articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursorCreatedAt, cursorArticleId, effectiveLimit + 1);
+        List<Article> articles = articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, effectiveLimit + 1);
         boolean hasNext = articles.size() > effectiveLimit;
         if (hasNext) articles.remove(articles.size() - 1);
 
+        return articles.stream()
+            .map(article -> {
+                Long articleId = article.getArticleId();
+
+                // 대표 이미지
+                String mainImageUuid = articlePhotoRepository.findFirstByArticleAndIsMainTrue(article)
+                    .map(ArticlePhoto::getFileKey)
+                    .orElseGet(() -> defaultImageUuid);
+                // 좋아요 여부
+                boolean isLiked = articleLikeRepository.existsById(
+                    new ArticleLikeId(articleId, memberId)
+                );
+                // 스팸 여부
+                boolean isSpammed = articleSpamRepository.existsById(
+                    new ArticleSpamId(articleId, memberId)
+                );
+                // 내 글 여부
+                boolean isMine = memberId.equals(article.getMember().getId());
+
+                log.debug("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);
+                return ArticleConverter.toArticleListItemDTO(article, mainImageUuid, isLiked, isSpammed, isMine);
+            })
+            .toList();
+    }
+
+    // V2: 복합 커서(LocalDateTime, Long) 방식
+    @Override
+    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleListV2(Long memberId, Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
+        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT;
+        Member member = memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+        Place place = placeRepository.findPlaceByPlaceId(placeId)
+            .orElseThrow(() -> new ArticleHandler(ErrorStatus.PLACE_NOT_FOUND));
+        List<Article> articles = articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, effectiveLimit + 1);
+        boolean hasNext = articles.size() > effectiveLimit;
+        if (hasNext) articles.remove(articles.size() - 1);
         return articles.stream()
             .map(article -> {
                 Long articleId = article.getArticleId();
@@ -160,7 +201,6 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
                     new ArticleSpamId(articleId, memberId)
                 );
                 boolean isMine = memberId.equals(article.getMember().getId());
-
                 log.debug("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);
                 return ArticleConverter.toArticleListItemDTO(article, mainImageUuid, isLiked, isSpammed, isMine);
             })

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImpl.java
@@ -36,6 +36,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Slf4j
@@ -134,39 +135,30 @@ public class ArticleQueryServiceImpl implements ArticleQueryService {
     }
 
     @Override
-    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, Long cursor, Long limit) {
-        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT; // limit가 null인 경우 기본값 설정
-
-        if (cursor == null || cursor == -1L) {
-            cursor = null;
-        }
+    public List<ArticleResponseDTO.ArticleListItemDTO> getArticleList(Long memberId, Long placeId, LocalDateTime cursorCreatedAt, Long cursorArticleId, Long limit) {
+        long effectiveLimit = (limit != null) ? limit : DEFAULT_LIMIT;
 
         Member member = memberRepository.findById(memberId)
             .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
         Place place = placeRepository.findPlaceByPlaceId(placeId)
             .orElseThrow(() -> new ArticleHandler(ErrorStatus.PLACE_NOT_FOUND));
         
-        List<Article> articles = articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, effectiveLimit + 1);
+        List<Article> articles = articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursorCreatedAt, cursorArticleId, effectiveLimit + 1);
         boolean hasNext = articles.size() > effectiveLimit;
         if (hasNext) articles.remove(articles.size() - 1);
 
         return articles.stream()
             .map(article -> {
                 Long articleId = article.getArticleId();
-
-                // 대표 이미지
                 String mainImageUuid = articlePhotoRepository.findFirstByArticleAndIsMainTrue(article)
                     .map(ArticlePhoto::getFileKey)
                     .orElseGet(() -> defaultImageUuid);
-                // 좋아요 여부
                 boolean isLiked = articleLikeRepository.existsById(
                     new ArticleLikeId(articleId, memberId)
                 );
-                // 스팸 여부
                 boolean isSpammed = articleSpamRepository.existsById(
                     new ArticleSpamId(articleId, memberId)
                 );
-                // 내 글 여부
                 boolean isMine = memberId.equals(article.getMember().getId());
 
                 log.debug("articleId: {}, isLiked: {}, isSpammed: {}, isMine: {}", articleId, isLiked, isSpammed, isMine);

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -119,23 +119,40 @@ public class ArticleController {
 
     @GetMapping
     @Operation(
-        summary = "게시물 목록 조회",
-        description = "게시물 목록을 조회합니다. JWT 인증 필요.",
+        summary = "게시물 목록 조회 (V1: 단일 커서(Long) 방식)",
+        description = "게시물 목록을 단일 커서(Long) 방식으로 조회합니다.\n\n- V1: 단일 커서(Long) 방식\n- placeId(장소 ID), cursor(마지막으로 조회한 게시글 ID), limit(페이지 크기) 사용\n- cursor가 null 또는 -1이면 첫 페이지 조회로 간주합니다.\n- JWT 인증 필요.",
         security = @SecurityRequirement(name = "JWT TOKEN")
     )
     public ResponseEntity<ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>>> getArticleList(
             @AuthenticationPrincipal MemberDetails memberDetails,
             @RequestParam("placeId") Long placeId,
-            @RequestParam(value = "cursorCreatedAt", required = false) String cursorCreatedAtStr,
-            @RequestParam(value = "cursorArticleId", required = false) Long cursorArticleId,
+            @RequestParam(value = "cursor", required = false) Long cursor,
             @RequestParam(value = "limit", required = false) Long limit
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
+        return ResponseEntity.status(SuccessStatus.ARTICLE_READ_SUCCESS.getHttpStatus()).body(ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, articles));
+    }
+
+    @GetMapping("/v2")
+    @Operation(
+        summary = "게시물 목록 조회 (V2: 복합 커서(LocalDateTime, Long) 방식)",
+        description = "게시물 목록을 복합 커서(LocalDateTime, Long) 방식으로 조회합니다.\n\n- V2: 복합 커서(LocalDateTime, Long) 방식\n- placeId(장소 ID), cursorCreatedAt(마지막 게시글 생성일시), cursorArticleId(마지막 게시글 ID), limit(페이지 크기) 사용\n- cursorCreatedAt, cursorArticleId가 null이면 첫 페이지 조회로 간주합니다.\n- JWT 인증 필요.",
+        security = @SecurityRequirement(name = "JWT TOKEN")
+    )
+    public ResponseEntity<ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>>> getArticleList(
+        @AuthenticationPrincipal MemberDetails memberDetails,
+        @RequestParam("placeId") Long placeId,
+        @RequestParam(value = "cursorCreatedAt", required = false) String cursorCreatedAtStr,
+        @RequestParam(value = "cursorArticleId", required = false) Long cursorArticleId,
+        @RequestParam(value = "limit", required = false) Long limit
     ) {
         Long memberId = memberDetails.getMember().getId();
         java.time.LocalDateTime cursorCreatedAt = null;
         if (cursorCreatedAtStr != null && !cursorCreatedAtStr.isBlank()) {
             cursorCreatedAt = java.time.LocalDateTime.parse(cursorCreatedAtStr);
         }
-        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
         return ResponseEntity.status(SuccessStatus.ARTICLE_READ_SUCCESS.getHttpStatus()).body(ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, articles));
     }
 }

--- a/src/main/java/DNBN/spring/web/controller/ArticleController.java
+++ b/src/main/java/DNBN/spring/web/controller/ArticleController.java
@@ -126,11 +126,16 @@ public class ArticleController {
     public ResponseEntity<ApiResponse<List<ArticleResponseDTO.ArticleListItemDTO>>> getArticleList(
             @AuthenticationPrincipal MemberDetails memberDetails,
             @RequestParam("placeId") Long placeId,
-            @RequestParam(value = "cursor", required = false) Long cursor,
+            @RequestParam(value = "cursorCreatedAt", required = false) String cursorCreatedAtStr,
+            @RequestParam(value = "cursorArticleId", required = false) Long cursorArticleId,
             @RequestParam(value = "limit", required = false) Long limit
     ) {
         Long memberId = memberDetails.getMember().getId();
-        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+        java.time.LocalDateTime cursorCreatedAt = null;
+        if (cursorCreatedAtStr != null && !cursorCreatedAtStr.isBlank()) {
+            cursorCreatedAt = java.time.LocalDateTime.parse(cursorCreatedAtStr);
+        }
+        List<ArticleResponseDTO.ArticleListItemDTO> articles = articleQueryService.getArticleList(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
         return ResponseEntity.status(SuccessStatus.ARTICLE_READ_SUCCESS.getHttpStatus()).body(ApiResponse.of(SuccessStatus.ARTICLE_READ_SUCCESS, articles));
     }
 }

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
@@ -119,7 +119,7 @@ class ArticleQueryServiceImplTest {
     * 일반적인 게시글 조회 검증
    */
   @Test
-  void getArticleList_정상_조회() {
+  void getArticleListV1_정상_조회() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -133,13 +133,13 @@ class ArticleQueryServiceImplTest {
 
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, limit + 1)).thenReturn(articles);
     when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
     when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
     when(articleSpamRepository.existsById(any())).thenReturn(false);
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     assertEquals(2, result.size());
@@ -155,7 +155,7 @@ class ArticleQueryServiceImplTest {
     * 게시물이 없을 때 빈 리스트가 반환되는지 검증
    */
   @Test
-  void getArticleList_게시물없을때_빈리스트_반환() {
+  void getArticleListV1_게시물없을때_빈리스트_반환() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -164,10 +164,10 @@ class ArticleQueryServiceImplTest {
 
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(List.of());
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, limit + 1)).thenReturn(List.of());
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     assertNotNull(result);
@@ -178,7 +178,7 @@ class ArticleQueryServiceImplTest {
     * Soft Delete로 삭제 처리된 게시물을 제외하고 조회되는지 검증
    */
   @Test
-  void getArticleList_삭제된_게시물_제외_정상_조회() {
+  void getArticleListV1_삭제된_게시물_제외_정상_조회() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -193,13 +193,13 @@ class ArticleQueryServiceImplTest {
 
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, limit + 1)).thenReturn(articles);
     when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
     when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
     when(articleSpamRepository.existsById(any())).thenReturn(false);
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     // 삭제된 게시물은 result에 포함되지 않아야 함
@@ -211,7 +211,7 @@ class ArticleQueryServiceImplTest {
     * 좋아요/스팸 처리를 한 게시글일 때, true로 반환되는지 검증
    */
   @Test
-  void getArticleList_좋아요_스팸_여부_검증() {
+  void getArticleListV1_좋아요_스팸_여부_검증() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -223,13 +223,13 @@ class ArticleQueryServiceImplTest {
 
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, limit + 1)).thenReturn(articles);
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, limit + 1)).thenReturn(articles);
     when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
     when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(true); // 좋아요 true
     when(articleSpamRepository.existsById(any())).thenReturn(true); // 스팸 true
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     // 좋아요/스팸 여부가 true로 반환되는지 검증
@@ -242,7 +242,7 @@ class ArticleQueryServiceImplTest {
     * limit가 null인 경우, 기본 limit(10)으로 처리되어야 하며 정상적으로 조회되는지 검증
    */
   @Test
-  void getArticleList_cursor_limit_null_정상_조회() {
+  void getArticleListV1_cursor_limit_null_정상_조회() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -255,13 +255,13 @@ class ArticleQueryServiceImplTest {
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
     // 기본 limit(10) + 1 = 11
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, cursor, 11L)).thenReturn(articles);
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, cursor, 11L)).thenReturn(articles);
     when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
     when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
     when(articleSpamRepository.existsById(any())).thenReturn(false);
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     // limit이 null이어도 정상적으로 조회되는지 검증
@@ -273,7 +273,7 @@ class ArticleQueryServiceImplTest {
     * cursor가 -1인 경우, null로 처리되어 정상적으로 조회되는지 검증
    */
   @Test
-  void getArticleList_cursor_마이너스1_정상_조회() {
+  void getArticleListV1_cursor_마이너스1_정상_조회() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -286,13 +286,13 @@ class ArticleQueryServiceImplTest {
     when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
     when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
     // cursor가 -1이면 null로 처리되어야 함
-    when(articleRepositoryCustom.findArticlesByPlaceWithCursor(placeId, null, limit + 1)).thenReturn(articles);
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV1(placeId, null, limit + 1)).thenReturn(articles);
     when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
     when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
     when(articleSpamRepository.existsById(any())).thenReturn(false);
 
     // when
-    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleList(memberId, placeId, cursor, limit);
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV1(memberId, placeId, cursor, limit);
 
     // then
     // cursor가 -1일 때도 정상적으로 조회되는지 검증
@@ -304,7 +304,7 @@ class ArticleQueryServiceImplTest {
    * Member가 존재하지 않을 때 예외 발생 검증
    */
   @Test
-  void getArticleList_멤버없음_예외() {
+  void getArticleListV1_멤버없음_예외() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -312,7 +312,7 @@ class ArticleQueryServiceImplTest {
 
     // when & then
     assertThrows(MemberHandler.class, () -> {
-      articleQueryService.getArticleList(memberId, placeId, null, null);
+      articleQueryService.getArticleListV1(memberId, placeId, null, null);
     });
   }
 
@@ -320,7 +320,7 @@ class ArticleQueryServiceImplTest {
    * Place가 존재하지 않을 때 예외 발생 검증
    */
   @Test
-  void getArticleList_장소없음_예외() {
+  void getArticleListV1_장소없음_예외() {
     // given
     Long memberId = 1L;
     Long placeId = 2L;
@@ -329,7 +329,7 @@ class ArticleQueryServiceImplTest {
 
     // when & then
     assertThrows(ArticleHandler.class, () -> {
-      articleQueryService.getArticleList(memberId, placeId, null, null);
+      articleQueryService.getArticleListV1(memberId, placeId, null, null);
     });
   }
 }

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleQueryServiceImplTest.java
@@ -332,5 +332,233 @@ class ArticleQueryServiceImplTest {
       articleQueryService.getArticleListV1(memberId, placeId, null, null);
     });
   }
-}
 
+  /*
+   * V2: 복합 커서(LocalDateTime, Long) 방식 정상 조회
+   */
+  @Test
+  void getArticleListV2_정상_조회() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime cursorCreatedAt = null;
+    Long cursorArticleId = null;
+    Long limit = 2L;
+
+    Article article1 = createArticle(10L, "제목1", "내용1", 5L, 0L, 1L);
+    Article article2 = createArticle(9L, "제목2", "내용2", 3L, 1L, 2L);
+    List<Article> articles = List.of(article1, article2);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+
+    // then
+    assertEquals(2, result.size());
+    assertEquals(article1.getArticleId(), result.get(0).getArticleId());
+    assertEquals(article2.getArticleId(), result.get(1).getArticleId());
+    assertEquals(DEFAULT_IMAGE_UUID, result.get(0).getMainImageUuid());
+    assertFalse(result.get(0).getIsLiked());
+    assertFalse(result.get(0).getIsSpammed());
+    assertTrue(result.get(0).getIsMine());
+  }
+
+  /*
+   * V2: createdAt 동률 시 articleId로 2차 정렬 및 커서 동작 검증
+   */
+  @Test
+  void getArticleListV2_createdAt동률_2차정렬_정상_조회() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime now = LocalDateTime.now();
+    Long limit = 2L;
+
+    Article article1 = createArticle(10L, "제목1", "내용1", 5L, 0L, 1L);
+    Article article2 = createArticle(9L, "제목2", "내용2", 3L, 1L, 2L);
+    // createdAt을 동일하게 맞춤
+    try {
+      Field createdAtField = Article.class.getSuperclass().getDeclaredField("createdAt");
+      createdAtField.setAccessible(true);
+      createdAtField.set(article1, now);
+      createdAtField.set(article2, now);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    List<Article> articles = List.of(article1, article2);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, now, 11L, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, now, 11L, limit);
+
+    // then
+    assertEquals(2, result.size());
+    assertEquals(article1.getArticleId(), result.get(0).getArticleId());
+    assertEquals(article2.getArticleId(), result.get(1).getArticleId());
+  }
+
+  /*
+   * V2: 게시물이 없을 때 빈 리스트 반환
+   */
+  @Test
+  void getArticleListV2_게시물없을때_빈리스트_반환() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime cursorCreatedAt = null;
+    Long cursorArticleId = null;
+    Long limit = 5L;
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, limit + 1)).thenReturn(List.of());
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+
+    // then
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  /*
+   * V2: 좋아요/스팸 여부 true 반환 검증
+   */
+  @Test
+  void getArticleListV2_좋아요_스팸_여부_검증() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime cursorCreatedAt = null;
+    Long cursorArticleId = null;
+    Long limit = 1L;
+
+    Article article = createArticle(10L, "제목", "내용", 1L, 1L, 0L);
+    List<Article> articles = List.of(article);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(true);
+    when(articleSpamRepository.existsById(any())).thenReturn(true);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+
+    // then
+    assertEquals(1, result.size());
+    assertTrue(result.get(0).getIsLiked());
+    assertTrue(result.get(0).getIsSpammed());
+  }
+
+  /*
+   * V2: limit가 null인 경우, 기본 limit(10)으로 처리
+   */
+  @Test
+  void getArticleListV2_limit_null_정상_조회() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime cursorCreatedAt = null;
+    Long cursorArticleId = null;
+    Long limit = null;
+
+    Article article = createArticle(10L, "제목", "내용", 0L, 0L, 0L);
+    List<Article> articles = List.of(article);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    // 기본 limit(10) + 1 = 11
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, 11L)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+
+    // then
+    assertEquals(1, result.size());
+    assertEquals(article.getArticleId(), result.get(0).getArticleId());
+  }
+
+  /*
+   * V2: Member가 존재하지 않을 때 예외 발생
+   */
+  @Test
+  void getArticleListV2_멤버없음_예외() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    when(memberRepository.findById(memberId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(MemberHandler.class, () -> {
+      articleQueryService.getArticleListV2(memberId, placeId, null, null, null);
+    });
+  }
+
+  /*
+   * V2: Place가 존재하지 않을 때 예외 발생
+   */
+  @Test
+  void getArticleListV2_장소없음_예외() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(ArticleHandler.class, () -> {
+      articleQueryService.getArticleListV2(memberId, placeId, null, null, null);
+    });
+  }
+
+  /*
+   * V2: Soft Delete로 삭제 처리된 게시물을 제외하고 조회되는지 검증
+   */
+  @Test
+  void getArticleListV2_삭제된_게시물_제외_정상_조회() {
+    // given
+    Long memberId = 1L;
+    Long placeId = 2L;
+    LocalDateTime cursorCreatedAt = null;
+    Long cursorArticleId = null;
+    Long limit = 3L;
+
+    Article article1 = createArticle(10L, "제목1", "내용1", 5L, 0L, 1L);
+    Article article2 = createArticle(9L, "제목2", "내용2", 3L, 1L, 2L);
+    Article deletedArticle = createDeletedArticle(8L, "삭제된글", "삭제됨", 3L, 4L, 5L);
+
+    List<Article> articles = List.of(article1, article2);
+
+    when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
+    when(placeRepository.findPlaceByPlaceId(placeId)).thenReturn(Optional.of(place));
+    when(articleRepositoryCustom.findArticlesByPlaceWithCursorV2(placeId, cursorCreatedAt, cursorArticleId, limit + 1)).thenReturn(articles);
+    when(articlePhotoRepository.findFirstByArticleAndIsMainTrue(any())).thenReturn(Optional.empty());
+    when(articleLikeRepository.existsById(any(ArticleLikeId.class))).thenReturn(false);
+    when(articleSpamRepository.existsById(any())).thenReturn(false);
+
+    // when
+    List<ArticleResponseDTO.ArticleListItemDTO> result = articleQueryService.getArticleListV2(memberId, placeId, cursorCreatedAt, cursorArticleId, limit);
+
+    // then
+    // 삭제된 게시물은 result에 포함되지 않아야 함
+    assertEquals(2, result.size());
+    assertTrue(result.stream().noneMatch(dto -> dto.getArticleId().equals(deletedArticle.getArticleId())));
+  }
+}


### PR DESCRIPTION
## #️⃣ 기능 설명
- createdAt 동률 발생 시 순서 불안정 문제를 해결하는 게시물 목록 조회 API 추가 (V2)
- 2차 정렬(PK) 및 복합 커서 조건 적용으로 페이징 일관성 보장
- 엔드포인트: `GET /api/articles/v2`
   

## 🛠️ 작업 상세 내용
- [x] V2 API 엔드포인트 및 서비스/레포지토리 구현
- [x] 명세에 V1/V2 방식 및 파라미터 표기
- [x] Swagger에 V1/V2 방식, 파라미터 차이, 커서 방식 명세
- [x] V1/V2 정상 동작 및 예외 상황 테스트
- [x]  테스트 코드 추가

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 버전을 분리해 별도의 API로 추가하였습니다.
  - **V1: 단일 커서(Long) 방식**
  - **V2: 복합 커서(LocalDateTime, Long) 방식**
  - 기존의 API (`cursorId`방식)으로 연동이 끝나 선택적으로 적용 가능하도록 하였습니다.
  - 실제로 사용하는 API는 변수명/메소드명을 제외하고 수정되지 않습니다.
- V2에서 추가된 파라미터:
  - **cursorCreatedAt**: 마지막으로 받은 게시글의 createdAt (String, 예: "2025-08-13T15:30:00")
  - **cursorArticleId**: 마지막으로 받은 게시글의 articleId (Long)

## 🧪 테스트 시나리오
- 정상 조회:
  - 커서 파라미터 없이 첫 페이지 정상 조회
- createdAt 동률 시 2차 정렬 및 커서 동작 검증:
  - createdAt이 동일한 게시글이 있을 때 articleId로 2차 정렬 및 페이징 일관성 검증
- 게시물이 없을 때 빈 리스트 반환
- 좋아요/스팸 여부 true 반환 검증
- limit가 null인 경우 기본 limit(10) 적용 검증
- 멤버가 존재하지 않을 때 예외 발생 검증
- 장소가 존재하지 않을 때 예외 발생 검증
- Soft Delete(삭제된 게시물) 제외 검증
  - 삭제된 게시물이 결과에 포함되지 않는지 확인