### PR TITLE
✨ [Feat] AOP 포인트컷 적용 범위 개선 및 파라미터 검증 추가

### DIFF
--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -25,6 +25,10 @@ public class ArticleValidationAspect {
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
     public void validateArticle(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
+        // 파라미터 타입/순서 검증
+        if (args.length < 2 || !(args[0] instanceof Long) || !(args[1] instanceof Long)) {
+            throw new IllegalArgumentException("❌ ArticleValidationAspect: memberId, articleId 파라미터 타입/순서 오류");
+        }
         Object dto = extractDto(args);
         Long memberId = extractLongArg(args, 0, "memberId");
         Long articleId = extractLongArg(args, 1, "articleId");

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -31,7 +31,14 @@ public class ArticleValidationAspect {
         }
         Object dto = extractDto(args);
         Long memberId = extractLongArg(args, 0, "memberId");
-        Long articleId = extractLongArg(args, 1, "articleId");
+        Long articleId = null;
+
+        if (args.length > 1 && args[1] instanceof Long) {
+            articleId = (Long) args[1];
+        }
+        if (articleId == null) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND);
+        }
 
         // PinCategory 검증
         validatePinCategory(dto);

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -26,7 +26,7 @@ public class ArticleValidationAspect {
     public void validateArticle(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         // 파라미터 타입/순서 검증
-        if (args.length < 2 || !(args[0] instanceof Long) || !(args[1] instanceof Long)) {
+        if (args.length < 2 || !(args[0] instanceof Long) || (args[1] != null && !(args[1] instanceof Long))) {
             throw new IllegalArgumentException("❌ ArticleValidationAspect: memberId, articleId 파라미터 타입/순서 오류");
         }
         Object dto = extractDto(args);

--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -52,7 +52,13 @@ public class CommentValidationAspect {
     }
 
     private Long extractLongArg(Object[] args, int idx, String name) {
-        if (args.length <= idx || !(args[idx] instanceof Long value)) {
+        if (args.length <= idx) {
+            throw new IllegalArgumentException("❌ CommentValidationAspect: " + name + " 인자 오류");
+        }
+        if (args[idx] == null) {
+            return null;
+        }
+        if (!(args[idx] instanceof Long value)) {
             throw new IllegalArgumentException("❌ CommentValidationAspect: " + name + " 인자 오류");
         }
         return value;

--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -25,6 +25,10 @@ public class CommentValidationAspect {
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateComment)")
     public void validateComment(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
+        // 파라미터 타입/순서 검증
+        if (args.length < 3 || !(args[0] instanceof Long) || !(args[1] instanceof Long) || !(args[2] instanceof Long)) {
+            throw new IllegalArgumentException("❌ CommentValidationAspect: memberId, commentId, articleId 파라미터 타입/순서 오류");
+        }
         Long memberId = extractLongArg(args, 0, "memberId");
         Long commentId = extractLongArg(args, 1, "commentId");
         Long articleId = extractLongArg(args, 2, "articleId");

--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -33,6 +33,10 @@ public class CommentValidationAspect {
         Long commentId = extractLongArg(args, 1, "commentId");
         Long articleId = extractLongArg(args, 2, "articleId");
         Comment comment = null;
+        // commentId가 null이면 예외 발생
+        if (args[1] == null) {
+            throw new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND);
+        }
         // createComment의 경우 parentCommentId만 존재
         if (commentId != null) {
             comment = commentRepository.findById(commentId)

--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -26,7 +26,7 @@ public class CommentValidationAspect {
     public void validateComment(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         // 파라미터 타입/순서 검증
-        if (args.length < 3 || !(args[0] instanceof Long) || !(args[1] instanceof Long) || !(args[2] instanceof Long)) {
+        if (args.length < 3 || !(args[0] instanceof Long) || (args[1] != null && !(args[1] instanceof Long)) || !(args[2] instanceof Long)) {
             throw new IllegalArgumentException("❌ CommentValidationAspect: memberId, commentId, articleId 파라미터 타입/순서 오류");
         }
         Long memberId = extractLongArg(args, 0, "memberId");

--- a/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
@@ -23,7 +23,7 @@ public class S3ImageValidationAspect {
     @Value("${article.validation.image.max-size}")
     private long maxImageSize;
 
-    @Before("execution(* *(.., org.springframework.web.multipart.MultipartFile, java.util.List, ..)) && @annotation(DNBN.spring.aop.annotation.ValidateS3ImageUpload)")
+    @Before("@annotation(DNBN.spring.aop.annotation.ValidateS3ImageUpload)")
     public void validateS3ImageUpload(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         MultipartFile mainImage = null;
@@ -64,4 +64,3 @@ public class S3ImageValidationAspect {
         }
     }
 }
-

--- a/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/S3ImageValidationAspect.java
@@ -26,41 +26,43 @@ public class S3ImageValidationAspect {
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateS3ImageUpload)")
     public void validateS3ImageUpload(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
-        MultipartFile mainImage = null;
-        List<MultipartFile> imageFiles = null;
+        int imageCount = 0;
+        // 파라미터 검증 및 다양한 MultipartFile 타입 지원
         for (Object arg : args) {
-            if (mainImage == null && arg instanceof MultipartFile file) {
-                mainImage = file;
-            } else if (imageFiles == null && arg instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof MultipartFile) {
-                imageFiles = (List<MultipartFile>) list;
-            }
-        }
-        int imageCount = (mainImage != null && !mainImage.isEmpty() ? 1 : 0)
-                + (imageFiles != null ? (int) imageFiles.stream().filter(f -> f != null && !f.isEmpty()).count() : 0);
-        if (imageCount > maxImageCount) {
-            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED);
-        }
-        if (mainImage != null && !mainImage.isEmpty()) {
-            if (mainImage.getSize() > maxImageSize) {
-                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
-            }
-            String contentType = mainImage.getContentType();
-            if (contentType == null || !contentType.startsWith("image/")) {
-                throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
-            }
-        }
-        if (imageFiles != null) {
-            for (MultipartFile file : imageFiles) {
-                if (file != null && !file.isEmpty()) {
-                    if (file.getSize() > maxImageSize) {
-                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+            if (arg instanceof MultipartFile file) {
+                if (!file.isEmpty()) {
+                    imageCount++;
+                    validateFile(file);
+                }
+            } else if (arg instanceof List<?> list && !list.isEmpty() && list.get(0) instanceof MultipartFile) {
+                for (Object o : list) {
+                    MultipartFile file = (MultipartFile) o;
+                    if (file != null && !file.isEmpty()) {
+                        imageCount++;
+                        validateFile(file);
                     }
-                    String contentType = file.getContentType();
-                    if (contentType == null || !contentType.startsWith("image/")) {
-                        throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
+                }
+            } else if (arg instanceof MultipartFile[] arr) {
+                for (MultipartFile file : arr) {
+                    if (file != null && !file.isEmpty()) {
+                        imageCount++;
+                        validateFile(file);
                     }
                 }
             }
+        }
+        if (imageCount > maxImageCount) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED);
+        }
+    }
+
+    private void validateFile(MultipartFile file) {
+        if (file.getSize() > maxImageSize) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE);
+        }
+        String contentType = file.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new ArticlePhotoHandler(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE);
         }
     }
 }

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/ArticleHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/ArticleHandler.java
@@ -7,4 +7,9 @@ public class ArticleHandler extends GeneralException {
     public ArticleHandler(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    @Override
+    public String getMessage() {
+        return getErrorReason().getMessage();
+    }
 }

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/ArticlePhotoHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/ArticlePhotoHandler.java
@@ -7,4 +7,9 @@ public class ArticlePhotoHandler extends GeneralException {
     public ArticlePhotoHandler(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    @Override
+    public String getMessage() {
+        return getErrorReason().getMessage();
+    }
 }

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/CommentHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/CommentHandler.java
@@ -7,4 +7,9 @@ public class CommentHandler extends GeneralException {
     public CommentHandler(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    @Override
+    public String getMessage() {
+        return getErrorReason().getMessage();
+    }
 }

--- a/src/main/java/DNBN/spring/apiPayload/exception/handler/PlaceHandler.java
+++ b/src/main/java/DNBN/spring/apiPayload/exception/handler/PlaceHandler.java
@@ -6,4 +6,9 @@ public class PlaceHandler extends GeneralException {
     public PlaceHandler(BaseErrorCode errorCode) {
         super(errorCode);
     }
+
+    @Override
+    public String getMessage() {
+        return getErrorReason().getMessage();
+    }
 }

--- a/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
@@ -1,0 +1,114 @@
+package DNBN.spring.aop;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.exception.handler.PlaceHandler;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Member;
+import DNBN.spring.domain.enums.PinCategory;
+import DNBN.spring.repository.ArticleRepository.ArticleRepository;
+import DNBN.spring.web.dto.request.ArticleRequestDTO;
+import DNBN.spring.web.dto.request.ArticleUpdateRequestDTO;
+import DNBN.spring.web.dto.request.ArticleWithLocationRequestDTO;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class ArticleValidationAspectTest {
+    private ArticleRepository articleRepository;
+    private ArticleValidationAspect aspect;
+
+    @BeforeEach
+    void setUp() {
+        articleRepository = mock(ArticleRepository.class);
+        aspect = new ArticleValidationAspect();
+        // 필드 주입 방식이므로 리플렉션으로 주입
+        java.lang.reflect.Field repoField;
+        try {
+            repoField = ArticleValidationAspect.class.getDeclaredField("articleRepository");
+            repoField.setAccessible(true);
+            repoField.set(aspect, articleRepository);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    @DisplayName("파라미터 타입/순서 오류시 예외 발생")
+    void parameterTypeOrderError() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"notLong", 1L});
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("파라미터 타입/순서 오류");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 articleId 예외 발생")
+    void notFoundArticle() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L});
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.empty());
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(ArticleHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자 예외 발생")
+    void forbiddenUser() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(99L); // 다른 사용자
+        when(article.getDeletedAt()).thenReturn(null);
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(ArticleHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 게시글 예외 발생")
+    void deletedArticle() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(article.getDeletedAt()).thenReturn(java.time.LocalDateTime.now());
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(ArticleHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("DTO의 pinCategory가 잘못된 경우 예외 발생")
+    void invalidPinCategory() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        ArticleRequestDTO dto = mock(ArticleRequestDTO.class);
+        when(dto.pinCategory()).thenReturn("invalid");
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null, dto});
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(PlaceHandler.class)
+                .hasMessageContaining(ErrorStatus.PIN_CATEGORY_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("DTO의 pinCategory가 정상인 경우 예외 없음")
+    void validPinCategory() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        ArticleRequestDTO dto = mock(ArticleRequestDTO.class);
+        when(dto.pinCategory()).thenReturn(PinCategory.FOOD.name());
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null, dto});
+        assertThatCode(() -> aspect.validateArticle(joinPoint)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
@@ -111,4 +111,90 @@ class ArticleValidationAspectTest {
         when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null, dto});
         assertThatCode(() -> aspect.validateArticle(joinPoint)).doesNotThrowAnyException();
     }
+
+    @Test
+    @DisplayName("articleId가 null인 경우 예외 발생")
+    void nullArticleId() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null});
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(ArticleHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("articleId 타입이 Long이 아닌 경우 예외 발생")
+    void articleIdNotLong() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, "stringId"});
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("파라미터 타입/순서 오류");
+    }
+
+    @Test
+    @DisplayName("ArticleRequestDTO가 null인 경우 예외 없음")
+    void nullArticleRequestDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, null});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(article.getDeletedAt()).thenReturn(null);
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatCode(() -> aspect.validateArticle(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("ArticleUpdateRequestDTO의 pinCategory가 잘못된 경우 예외 발생")
+    void invalidPinCategoryInUpdateDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        ArticleUpdateRequestDTO dto = mock(ArticleUpdateRequestDTO.class);
+        when(dto.pinCategory()).thenReturn("invalid");
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, dto});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(article.getDeletedAt()).thenReturn(null);
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(PlaceHandler.class)
+                .hasMessageContaining(ErrorStatus.PIN_CATEGORY_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("ArticleWithLocationRequestDTO의 pinCategory가 잘못된 경우 예외 발생")
+    void invalidPinCategoryInWithLocationDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        ArticleWithLocationRequestDTO dto = mock(ArticleWithLocationRequestDTO.class);
+        when(dto.pinCategory()).thenReturn("invalid");
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, dto});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(article.getDeletedAt()).thenReturn(null);
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
+                .isInstanceOf(PlaceHandler.class)
+                .hasMessageContaining(ErrorStatus.PIN_CATEGORY_INVALID.getMessage());
+    }
+
+    @Test
+    @DisplayName("ArticleUpdateRequestDTO의 pinCategory가 정상인 경우 예외 없음")
+    void validPinCategoryInUpdateDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        ArticleUpdateRequestDTO dto = mock(ArticleUpdateRequestDTO.class);
+        when(dto.pinCategory()).thenReturn(PinCategory.FOOD.name());
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, dto});
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(article.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(article.getDeletedAt()).thenReturn(null);
+        when(articleRepository.findById(2L)).thenReturn(java.util.Optional.of(article));
+        assertThatCode(() -> aspect.validateArticle(joinPoint)).doesNotThrowAnyException();
+    }
 }

--- a/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/ArticleValidationAspectTest.java
@@ -117,6 +117,7 @@ class ArticleValidationAspectTest {
     void nullArticleId() {
         JoinPoint joinPoint = mock(JoinPoint.class);
         when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null});
+        when(articleRepository.findById(null)).thenReturn(java.util.Optional.empty());
         assertThatThrownBy(() -> aspect.validateArticle(joinPoint))
                 .isInstanceOf(ArticleHandler.class)
                 .hasMessageContaining(ErrorStatus.ARTICLE_NOT_FOUND.getMessage());

--- a/src/test/java/DNBN/spring/aop/CommentValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/CommentValidationAspectTest.java
@@ -1,0 +1,105 @@
+package DNBN.spring.aop;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.CommentHandler;
+import DNBN.spring.domain.Comment;
+import DNBN.spring.domain.Article;
+import DNBN.spring.domain.Member;
+import DNBN.spring.repository.CommentRepository.CommentRepository;
+import DNBN.spring.web.dto.request.CommentRequestDTO;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class CommentValidationAspectTest {
+    private CommentRepository commentRepository;
+    private CommentValidationAspect aspect;
+
+    @BeforeEach
+    void setUp() {
+        commentRepository = mock(CommentRepository.class);
+        aspect = new CommentValidationAspect(commentRepository);
+    }
+
+    @Test
+    @DisplayName("파라미터 타입/순서 오류시 예외 발생")
+    void parameterTypeOrderError() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{"notLong", 1L, 2L});
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("파라미터 타입/순서 오류");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 commentId 예외 발생")
+    void notFoundComment() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, 3L});
+        when(commentRepository.findById(2L)).thenReturn(java.util.Optional.empty());
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(CommentHandler.class)
+                .hasMessageContaining(ErrorStatus.COMMENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("권한 없는 사용자 예외 발생")
+    void forbiddenUser() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, 3L});
+        Comment comment = mock(Comment.class);
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(comment.getArticle()).thenReturn(article);
+        when(article.getArticleId()).thenReturn(3L);
+        when(comment.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(99L); // 다른 사용자
+        when(comment.getDeletedAt()).thenReturn(null);
+        when(commentRepository.findById(2L)).thenReturn(java.util.Optional.of(comment));
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(CommentHandler.class)
+                .hasMessageContaining(ErrorStatus.COMMENT_FORBIDDEN.getMessage());
+    }
+
+    @Test
+    @DisplayName("삭제된 댓글 예외 발생")
+    void deletedComment() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, 3L});
+        Comment comment = mock(Comment.class);
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(comment.getArticle()).thenReturn(article);
+        when(article.getArticleId()).thenReturn(3L);
+        when(comment.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(comment.getDeletedAt()).thenReturn(java.time.LocalDateTime.now());
+        when(commentRepository.findById(2L)).thenReturn(java.util.Optional.of(comment));
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(CommentHandler.class)
+                .hasMessageContaining(ErrorStatus.COMMENT_ALREADY_DELETED.getMessage());
+    }
+
+    @Test
+    @DisplayName("parentCommentId가 존재하고, articleId 불일치시 예외 발생")
+    void parentCommentArticleIdMismatch() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        CommentRequestDTO dto = mock(CommentRequestDTO.class);
+        when(dto.parentCommentId()).thenReturn(10L);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null, 3L, dto});
+        Comment parentComment = mock(Comment.class);
+        Article article = mock(Article.class);
+        when(parentComment.getArticle()).thenReturn(article);
+        when(article.getArticleId()).thenReturn(99L); // 불일치
+        when(commentRepository.findById(10L)).thenReturn(java.util.Optional.of(parentComment));
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(CommentHandler.class)
+                .hasMessageContaining(ErrorStatus.COMMENT_FORBIDDEN.getMessage());
+    }
+}
+

--- a/src/test/java/DNBN/spring/aop/CommentValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/CommentValidationAspectTest.java
@@ -7,6 +7,7 @@ import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.CommentRepository.CommentRepository;
 import DNBN.spring.web.dto.request.CommentRequestDTO;
+import DNBN.spring.web.dto.request.CommentUpdateRequestDTO;
 import org.aspectj.lang.JoinPoint;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -101,5 +102,71 @@ class CommentValidationAspectTest {
                 .isInstanceOf(CommentHandler.class)
                 .hasMessageContaining(ErrorStatus.COMMENT_FORBIDDEN.getMessage());
     }
-}
 
+    @Test
+    @DisplayName("commentId가 null인 경우 예외 발생")
+    void nullCommentId() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, null, 3L});
+        when(commentRepository.findById(null)).thenReturn(java.util.Optional.empty());
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(CommentHandler.class)
+                .hasMessageContaining(ErrorStatus.COMMENT_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    @DisplayName("commentId 타입이 Long이 아닌 경우 예외 발생")
+    void commentIdNotLong() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, "stringId", 3L});
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("파라미터 타입/순서 오류");
+    }
+
+    @Test
+    @DisplayName("articleId가 null인 경우 예외 발생")
+    void nullArticleId() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, null});
+        assertThatThrownBy(() -> aspect.validateComment(joinPoint))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("파라미터 타입/순서 오류");
+    }
+
+    @Test
+    @DisplayName("CommentRequestDTO가 null인 경우 예외 없음")
+    void nullCommentRequestDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, 3L, null});
+        Comment comment = mock(Comment.class);
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(comment.getArticle()).thenReturn(article);
+        when(article.getArticleId()).thenReturn(3L);
+        when(comment.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(comment.getDeletedAt()).thenReturn(null);
+        when(commentRepository.findById(2L)).thenReturn(java.util.Optional.of(comment));
+        assertThatCode(() -> aspect.validateComment(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("CommentRequestDTO의 parentCommentId가 null인 경우 예외 없음")
+    void parentCommentIdNullInDto() {
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        CommentRequestDTO dto = mock(CommentRequestDTO.class);
+        when(dto.parentCommentId()).thenReturn(null);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{1L, 2L, 3L, dto});
+        Comment comment = mock(Comment.class);
+        Article article = mock(Article.class);
+        Member member = mock(Member.class);
+        when(comment.getArticle()).thenReturn(article);
+        when(article.getArticleId()).thenReturn(3L);
+        when(comment.getMember()).thenReturn(member);
+        when(member.getId()).thenReturn(1L);
+        when(comment.getDeletedAt()).thenReturn(null);
+        when(commentRepository.findById(2L)).thenReturn(java.util.Optional.of(comment));
+        assertThatCode(() -> aspect.validateComment(joinPoint)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/DNBN/spring/aop/S3ImageValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/S3ImageValidationAspectTest.java
@@ -103,5 +103,55 @@ class S3ImageValidationAspectTest {
         when(joinPoint.getArgs()).thenReturn(new Object[]{files});
         assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
     }
-}
 
+    @Test
+    @DisplayName("contentType이 null인 경우 예외 발생")
+    void nullContentType() {
+        MultipartFile file = mockImage(100_000, null, false);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{file});
+        assertThatThrownBy(() -> aspect.validateS3ImageUpload(joinPoint))
+                .isInstanceOf(ArticlePhotoHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE.getMessage());
+    }
+
+    @Test
+    @DisplayName("List<MultipartFile>에 null 요소가 포함된 경우 NPE 없이 동작")
+    void listWithNullElement() {
+        MultipartFile file1 = mockImage(100_000, "image/png", false);
+        List<MultipartFile> files = Arrays.asList(file1, null);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{files});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("MultipartFile[]에 null 요소가 포함된 경우 NPE 없이 동작")
+    void arrayWithNullElement() {
+        MultipartFile file1 = mockImage(100_000, "image/png", false);
+        MultipartFile[] arr = new MultipartFile[]{file1, null};
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{arr});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("모든 파일이 empty인 경우 예외 없음")
+    void allFilesEmpty() {
+        MultipartFile file1 = mockImage(100_000, "image/png", true);
+        MultipartFile file2 = mockImage(100_000, "image/png", true);
+        MultipartFile[] arr = new MultipartFile[]{file1, file2};
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{arr});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 파라미터 타입이 들어온 경우 무시")
+    void unsupportedParameterType() {
+        String notAFile = "not a file";
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{notAFile});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+}

--- a/src/test/java/DNBN/spring/aop/S3ImageValidationAspectTest.java
+++ b/src/test/java/DNBN/spring/aop/S3ImageValidationAspectTest.java
@@ -1,0 +1,107 @@
+package DNBN.spring.aop;
+
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
+import DNBN.spring.apiPayload.exception.handler.ArticlePhotoHandler;
+import org.aspectj.lang.JoinPoint;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.*;
+
+class S3ImageValidationAspectTest {
+    private S3ImageValidationAspect aspect;
+    private final int maxImageCount = 3;
+    private final long maxImageSize = 1024 * 1024; // 1MB
+
+    @BeforeEach
+    void setUp() {
+        aspect = new S3ImageValidationAspect();
+        ReflectionTestUtils.setField(aspect, "maxImageCount", maxImageCount);
+        ReflectionTestUtils.setField(aspect, "maxImageSize", maxImageSize);
+    }
+
+    private MultipartFile mockImage(long size, String contentType, boolean empty) {
+        MultipartFile file = mock(MultipartFile.class);
+        when(file.isEmpty()).thenReturn(empty);
+        when(file.getSize()).thenReturn(size);
+        when(file.getContentType()).thenReturn(contentType);
+        return file;
+    }
+
+    @Test
+    @DisplayName("정상 이미지 파일 1개 업로드시 예외 없음")
+    void validSingleImage() {
+        MultipartFile file = mockImage(500_000, "image/png", false);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{file});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("이미지 개수 초과시 예외 발생")
+    void imageCountExceeded() {
+        MultipartFile file1 = mockImage(100_000, "image/png", false);
+        MultipartFile file2 = mockImage(100_000, "image/png", false);
+        MultipartFile file3 = mockImage(100_000, "image/png", false);
+        MultipartFile file4 = mockImage(100_000, "image/png", false);
+        List<MultipartFile> files = Arrays.asList(file1, file2, file3, file4);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{files});
+        assertThatThrownBy(() -> aspect.validateS3ImageUpload(joinPoint))
+                .isInstanceOf(ArticlePhotoHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_PHOTO_IMAGE_COUNT_EXCEEDED.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미지 크기 초과시 예외 발생")
+    void imageSizeExceeded() {
+        MultipartFile file = mockImage(maxImageSize + 1, "image/png", false);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{file});
+        assertThatThrownBy(() -> aspect.validateS3ImageUpload(joinPoint))
+                .isInstanceOf(ArticlePhotoHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_PHOTO_IMAGE_TOO_LARGE.getMessage());
+    }
+
+    @Test
+    @DisplayName("이미지 타입이 아닌 경우 예외 발생")
+    void invalidImageType() {
+        MultipartFile file = mockImage(100_000, "application/pdf", false);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{file});
+        assertThatThrownBy(() -> aspect.validateS3ImageUpload(joinPoint))
+                .isInstanceOf(ArticlePhotoHandler.class)
+                .hasMessageContaining(ErrorStatus.ARTICLE_PHOTO_IMAGE_INVALID_TYPE.getMessage());
+    }
+
+    @Test
+    @DisplayName("MultipartFile[] 타입도 정상 동작")
+    void multipartFileArray() {
+        MultipartFile file1 = mockImage(100_000, "image/png", false);
+        MultipartFile file2 = mockImage(100_000, "image/png", false);
+        MultipartFile[] arr = new MultipartFile[]{file1, file2};
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{arr});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+
+    @Test
+    @DisplayName("빈 파일/빈 리스트는 무시")
+    void emptyFilesIgnored() {
+        MultipartFile file = mockImage(100_000, "image/png", true);
+        List<MultipartFile> files = Collections.singletonList(file);
+        JoinPoint joinPoint = mock(JoinPoint.class);
+        when(joinPoint.getArgs()).thenReturn(new Object[]{files});
+        assertThatCode(() -> aspect.validateS3ImageUpload(joinPoint)).doesNotThrowAnyException();
+    }
+}
+


### PR DESCRIPTION
## #️⃣ 기능 설명
- AOP 기반 검증 Aspect의 포인트컷 적용 범위를 어노테이션 기반으로 축소
- 파라미터 타입/순서 검증 및 예외 처리를 강화
- 각 Aspect별 단위 테스트 추가

## 🛠️ 작업 상세 내용
- [x] CommentValidationAspect, ArticleValidationAspect, S3ImageValidationAspect에 파라미터 타입/순서 검증 로직 추가
- [x] S3ImageValidationAspect 포인트컷을 어노테이션 기반으로 변경
- [x] commentId, articleId 등 주요 파라미터가 null이거나 타입이 잘못된 경우 예외 발생하도록 검증 로직 강화
- [x] 각 Aspect별 단위 테스트 추가 및 케이스 보강

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 테스트 검증을 위해 Handler들의 `getMessage()`를 다음과 같이 오버라이드 하였습니다.
  - 프론트 응답에는 변동이 없음을 확인하였습니다.

```java
@Override
    public String getMessage() {
        return getErrorReason().getMessage();
    }
```