### PR TITLE
🔨 [Fix] 기본 이미지 목록 조회 경로 수정

### DIFF
--- a/src/main/java/DNBN/spring/web/controller/DefaultImageController.java
+++ b/src/main/java/DNBN/spring/web/controller/DefaultImageController.java
@@ -37,7 +37,7 @@ public class DefaultImageController {
         "af1ca572-0298-4931-908d-3362d588bc7a"
     };
 
-    @GetMapping("/default-images")
+    @GetMapping
     public ResponseEntity<ApiResponse<List<String>>> getDefaultImageUrls() {
         List<String> urls = java.util.Arrays.stream(UUIDS)
                 .map(uuid -> S3_BASE_URL + uuid)


### PR DESCRIPTION
## #️⃣ 기능 설명
> 기본 이미지 목록 조회 api의 경로를 `/api/default-images/default-images`에서 `/api/default-images`로 수정

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
