### PR TITLE
♻️ [Refactor] ArticleValidationAspect.validateArticle 클린코드 리팩토링

### DIFF
--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -19,6 +19,10 @@ import org.springframework.stereotype.Component;
 @Aspect
 @Component
 public class ArticleValidationAspect {
+    private static final int MEMBER_ID_INDEX = 0;
+    private static final int ARTICLE_ID_INDEX = 1;
+    private static final String PARAMETER_ERROR_MESSAGE = "❌ ArticleValidationAspect: memberId 파라미터 타입/순서 오류";
+    
     @Autowired
     private ArticleRepository articleRepository;
 
@@ -26,15 +30,15 @@ public class ArticleValidationAspect {
     public void validateArticle(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
         // 파라미터 타입/순서 검증
-        if (args.length < 1 || !(args[0] instanceof Long)) {
-            throw new IllegalArgumentException("❌ ArticleValidationAspect: memberId 파라미터 타입/순서 오류");
+        if (args.length < 1 || !(args[MEMBER_ID_INDEX] instanceof Long)) {
+            throw new IllegalArgumentException(PARAMETER_ERROR_MESSAGE);
         }
 
-        Long memberId = (Long) args[0];
+        Long memberId = (Long) args[MEMBER_ID_INDEX];
         Long articleId = null;
         // 두 번째 인자가 Long이면 articleId로 간주 (생성 시에는 null)
-        if (args.length > 1 && args[1] instanceof Long) {
-            articleId = (Long) args[1];
+        if (args.length > 1 && args[ARTICLE_ID_INDEX] instanceof Long) {
+            articleId = (Long) args[ARTICLE_ID_INDEX];
         }
 
         Object dto = extractDto(args);

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -37,17 +37,9 @@ public class ArticleValidationAspect {
         Object dto = extractDto(args);
         
         validatePinCategory(dto);
-
-        // articleId가 있으면(수정/삭제) 권한 및 삭제 여부 검증, 없으면(생성) 생략
+        
         if (articleId != null) {
-            Article article = articleRepository.findById(articleId)
-                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
-            if (!article.getMember().getId().equals(memberId)) {
-                throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
-            }
-            if (article.getDeletedAt() != null) {
-                throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
-            }
+            validateArticleAccess(memberId, articleId);
         }
     }
 
@@ -120,5 +112,28 @@ public class ArticleValidationAspect {
             return value;
         }
         return null;
+    }
+
+    private void validateArticleAccess(Long memberId, Long articleId) {
+        Article article = findArticleById(articleId);
+        validateArticleOwnership(article, memberId);
+        validateArticleNotDeleted(article);
+    }
+
+    private Article findArticleById(Long articleId) {
+        return articleRepository.findById(articleId)
+            .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
+    }
+
+    private void validateArticleOwnership(Article article, Long memberId) {
+        if (!article.getMember().getId().equals(memberId)) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
+        }
+    }
+
+    private void validateArticleNotDeleted(Article article) {
+        if (article.getDeletedAt() != null) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
+        }
     }
 }

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -85,35 +85,6 @@ public class ArticleValidationAspect {
         return null;
     }
 
-    private Pair<String, String> extractTitleAndContentFromRecord(Object recordDto) {
-        try {
-            var titleMethod = recordDto.getClass().getMethod("title");
-            var contentMethod = recordDto.getClass().getMethod("content");
-            String title = (String) titleMethod.invoke(recordDto);
-            String content = (String) contentMethod.invoke(recordDto);
-
-            return Pair.of(title, content);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("❌ ArticleValidationAspect: DTO에서 title/content 추출 실패", e);
-        }
-    }
-
-    private void validateLength(String value, int min, int max, ErrorStatus nullErrorStatus, ErrorStatus lengthErrorStatus) {
-        if (value == null) {
-            throw new ArticleHandler(nullErrorStatus);
-        }
-        if (value.length() < min || value.length() > max) {
-            throw new ArticleHandler(lengthErrorStatus);
-        }
-    }
-
-    private Long extractLongArg(Object[] args, int idx, String name) {
-        if (args.length > idx && args[idx] instanceof Long value) {
-            return value;
-        }
-        return null;
-    }
-
     private void validateArticleAccess(Long memberId, Long articleId) {
         Article article = findArticleById(articleId);
         validateArticleOwnership(article, memberId);

--- a/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/ArticleValidationAspect.java
@@ -29,19 +29,13 @@ public class ArticleValidationAspect {
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
     public void validateArticle(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
-        // 파라미터 타입/순서 검증
-        if (args.length < 1 || !(args[MEMBER_ID_INDEX] instanceof Long)) {
-            throw new IllegalArgumentException(PARAMETER_ERROR_MESSAGE);
-        }
-
-        Long memberId = (Long) args[MEMBER_ID_INDEX];
-        Long articleId = null;
-        // 두 번째 인자가 Long이면 articleId로 간주 (생성 시에는 null)
-        if (args.length > 1 && args[ARTICLE_ID_INDEX] instanceof Long) {
-            articleId = (Long) args[ARTICLE_ID_INDEX];
-        }
-
+        
+        validateParameterStructure(args);
+        
+        Long memberId = extractMemberId(args);
+        Long articleId = extractArticleId(args);
         Object dto = extractDto(args);
+        
         validatePinCategory(dto);
 
         // articleId가 있으면(수정/삭제) 권한 및 삭제 여부 검증, 없으면(생성) 생략
@@ -54,6 +48,12 @@ public class ArticleValidationAspect {
             if (article.getDeletedAt() != null) {
                 throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
             }
+        }
+    }
+
+    private void validateParameterStructure(Object[] args) {
+        if (args.length < 1 || !(args[MEMBER_ID_INDEX] instanceof Long)) {
+            throw new IllegalArgumentException(PARAMETER_ERROR_MESSAGE);
         }
     }
 
@@ -78,6 +78,17 @@ public class ArticleValidationAspect {
                 arg instanceof ArticleUpdateRequestDTO) {
                 return arg;
             }
+        }
+        return null;
+    }
+
+    private Long extractMemberId(Object[] args) {
+        return (Long) args[MEMBER_ID_INDEX];
+    }
+
+    private Long extractArticleId(Object[] args) {
+        if (args.length > 1 && args[ARTICLE_ID_INDEX] instanceof Long) {
+            return (Long) args[ARTICLE_ID_INDEX];
         }
         return null;
     }


### PR DESCRIPTION
## #️⃣ 기능 설명
> ArticleValidationAspect의 validateArticle 메소드를 클린코드 원칙에 따라 리팩토링하여 가독성, 유지보수성, 테스트 용이성 향상

## 🛠️ 작업 상세 내용
- [x] **매직 넘버 상수화**: `args[0]`, `args[1]` → `MEMBER_ID_INDEX`, `ARTICLE_ID_INDEX`로 변경
- [x] **에러 메시지 상수화**: 하드코딩된 에러 메시지를 `PARAMETER_ERROR_MESSAGE` 상수로 분리
- [x] **파라미터 추출 로직 분리**: 
  - `validateParameterStructure()`: 파라미터 구조 검증
  - `extractMemberId()`: memberId 추출
  - `extractArticleId()`: articleId 추출
- [x] **게시글 접근 검증 로직 분리**:
  - `validateArticleAccess()`: 게시글 접근 권한 검증
  - `findArticleById()`: 게시글 조회
  - `validateArticleOwnership()`: 소유권 검증
  - `validateArticleNotDeleted()`: 삭제 여부 검증
- [x] **사용하지 않는 메소드 정리**: `extractTitleAndContentFromRecord`, `validateLength`, `extractLongArg` 제거

## 📸 스크린샷 (선택)

### Before (리팩토링 전)
```java
@Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
public void validateArticle(JoinPoint joinPoint) {
    Object[] args = joinPoint.getArgs();
    // 파라미터 타입/순서 검증
    if (args.length < 1 || !(args[0] instanceof Long)) {
        throw new IllegalArgumentException("❌ ArticleValidationAspect: memberId 파라미터 타입/순서 오류");
    }

    Long memberId = (Long) args[0];
    Long articleId = null;
    // 두 번째 인자가 Long이면 articleId로 간주 (생성 시에는 null)
    if (args.length > 1 && args[1] instanceof Long) {
        articleId = (Long) args[1];
    }

    Object dto = extractDto(args);
    validatePinCategory(dto);

    // articleId가 있으면(수정/삭제) 권한 및 삭제 여부 검증, 없으면(생성) 생략
    if (articleId != null) {
        Article article = articleRepository.findById(articleId)
            .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
        if (!article.getMember().getId().equals(memberId)) {
            throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
        }
        if (article.getDeletedAt() != null) {
            throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
        }
    }
}
```

### After (리팩토링 후)
```java
@Before("@annotation(DNBN.spring.aop.annotation.ValidateArticle)")
public void validateArticle(JoinPoint joinPoint) {
    Object[] args = joinPoint.getArgs();
    
    validateParameterStructure(args);
    
    Long memberId = extractMemberId(args);
    Long articleId = extractArticleId(args);
    Object dto = extractDto(args);
    
    validatePinCategory(dto);
    
    if (articleId != null) {
        validateArticleAccess(memberId, articleId);
    }
}

private void validateParameterStructure(Object[] args) {
    if (args.length < 1 || !(args[MEMBER_ID_INDEX] instanceof Long)) {
        throw new IllegalArgumentException(PARAMETER_ERROR_MESSAGE);
    }
}

private Long extractMemberId(Object[] args) {
    return (Long) args[MEMBER_ID_INDEX];
}

private Long extractArticleId(Object[] args) {
    if (args.length > 1 && args[ARTICLE_ID_INDEX] instanceof Long) {
        return (Long) args[ARTICLE_ID_INDEX];
    }
    return null;
}

private void validateArticleAccess(Long memberId, Long articleId) {
    Article article = findArticleById(articleId);
    validateArticleOwnership(article, memberId);
    validateArticleNotDeleted(article);
}

private Article findArticleById(Long articleId) {
    return articleRepository.findById(articleId)
        .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
}

private void validateArticleOwnership(Article article, Long memberId) {
    if (!article.getMember().getId().equals(memberId)) {
        throw new ArticleHandler(ErrorStatus.ARTICLE_FORBIDDEN);
    }
}

private void validateArticleNotDeleted(Article article) {
    if (article.getDeletedAt() != null) {
        throw new ArticleHandler(ErrorStatus.ARTICLE_ALREADY_DELETED);
    }
}
```

## 💬 기타(공유사항 to 리뷰어)
- #213 
  - 이전 hotfix의 재발방지를 위해 작업하였습니다.
- 사용하지 않는 메소드를 정리하였습니다.
- 다른 코드들도 같은 작업이 필요한데, 테스트 코드가 더 급하다 생각해 후순위로 두고 있습니다.
  - 후에도 문제가 생길 수 있는 코드를 발견하면 중간중간 리팩토링 하도록 하겠습니다.