### PR TITLE
♻️ [Refactor] 카테고리 삭제 시 장소 저장 해제 로직 추가

### DIFF
--- a/src/main/java/DNBN/spring/converter/PlaceConverter.java
+++ b/src/main/java/DNBN/spring/converter/PlaceConverter.java
@@ -34,7 +34,7 @@ public class PlaceConverter {
         List<PlaceResponseDTO.MapPlaceDTO> list = places.stream()
                 .map(p -> {
                     boolean saved = savePlaceRepository
-                            .existsByPlace_PlaceIdAndCategory_Member_Id(p.getPlaceId(), memberId);
+                            .existsByPlace_PlaceIdAndCategory_Member_IdAndCategory_DeletedAtIsNull(p.getPlaceId(), memberId);
                     return PlaceResponseDTO.MapPlaceDTO.builder()
                             .placeId(p.getPlaceId())
                             .regionId(p.getRegion().getId())

--- a/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepository.java
@@ -14,8 +14,6 @@ public interface PlaceRepository extends JpaRepository<Place, Long> {
 
     Optional<Place> findPlaceByPlaceId(Long placeId);
 
-    Optional<Place> findByLatitudeAndLongitude(Double lat, Double lng);
-
     List<Place> findByRegionId(Long regionId);
 
 }

--- a/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/PlaceRepository/PlaceRepositoryImpl.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.List;
 
+import static DNBN.spring.domain.QCategory.category;
+
 @Repository
 @RequiredArgsConstructor
 public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
@@ -20,7 +22,6 @@ public class PlaceRepositoryImpl implements PlaceRepositoryCustom {
         BooleanBuilder b = new BooleanBuilder();
         b.and(place.latitude.between(latMin, latMax))
                 .and(place.longitude.between(lngMin, lngMax));
-//                .and(place.deletedAt.isNull()); // 필요하다면 삭제 여부 체크
 
         return queryFactory
                 .selectFrom(place)

--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 public interface SavePlaceRepository extends JpaRepository<SavePlace, Long>, SavePlaceRepositoryCustom {
     boolean existsByPlace(Place place);
-    boolean existsByPlace_PlaceIdAndCategory_Member_Id(Long placeId, Long memberId);
+    boolean existsByPlace_PlaceIdAndCategory_Member_IdAndCategory_DeletedAtIsNull(Long placeId, Long memberId);
 }

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceQueryServiceImpl.java
@@ -51,15 +51,6 @@ public class PlaceQueryServiceImpl implements PlaceQueryService {
                 .build();
     }
 
-//    @Override
-//    public PlaceResponseDTO.MapPlacesResultDTO getPlacesInMapBounds(PlaceRequestDTO.MapSearchDTO request) {
-//        List<Place> places = placeRepositoryCustom.findAllInBounds(
-//                request.getLatMin(), request.getLatMax(),
-//                request.getLngMin(), request.getLngMax()
-//        );
-//        return PlaceConverter.toMapPlacesResult(places);
-//    }
-
     @Override
     public PlaceResponseDTO.MapPlacesResultDTO getPlacesInMapBounds(
             Long memberId, Double latMin, Double latMax, Double lngMin, Double lngMax


### PR DESCRIPTION
## #️⃣ 기능 설명
> 카테고리 삭제 후 지도 조회에서 isSaved가 계속 true로 보이는 문제 수정

## 🛠️ 작업 상세 내용
- [x] SavePlaceRepository에 existsByPlace_PlaceIdAndCategory_Member_IdAndCategory_DeletedAtIsNull메서드 추가
- [x] PlaceConverter.toMapPlacesResult에서 isSaved 판단을 위 메서드로 교체
- [x] 삭제된 카테고리를 통한 저장은 즉시 false로 반영되고, 다른 활성 카테고리에 저장된 경우는 true를 유지

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
카테고리 생성→장소 저장→조회 시 true 확인→카테고리 소프트 삭제→다시 조회 시 false 확인