### PR TITLE
🔨 [Fix] 해당 장소 저장된 카테고리 삭제 후 장소 저장 로직 수정

### DIFF
--- a/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
+++ b/src/main/java/DNBN/spring/repository/SavePlaceRepository/SavePlaceRepository.java
@@ -8,6 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface SavePlaceRepository extends JpaRepository<SavePlace, Long>, SavePlaceRepositoryCustom {
-    boolean existsByPlace(Place place);
     boolean existsByPlace_PlaceIdAndCategory_Member_IdAndCategory_DeletedAtIsNull(Long placeId, Long memberId);
 }

--- a/src/main/java/DNBN/spring/service/PlaceService/PlaceCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/PlaceService/PlaceCommandServiceImpl.java
@@ -43,8 +43,8 @@ public class PlaceCommandServiceImpl implements PlaceCommandService {
                 .findByCategoryIdAndMemberAndDeletedAtIsNull(request.getCategoryId(), member)
                 .orElseThrow(() -> new CategoryHandler(ErrorStatus._FORBIDDEN));
 
-        // 4. 이미 다른 카테고리에 저장된 장소인지 검사
-        if (savePlaceRepository.existsByPlace(place)) {
+        // 4. 중복 저장 여부
+        if (savePlaceRepository.existsByPlace_PlaceIdAndCategory_Member_IdAndCategory_DeletedAtIsNull(placeId, memberId)) {
             throw new PlaceHandler(ErrorStatus.CATEGORY_ALREADY_SAVED_FOR_PLACE);
         }
 


### PR DESCRIPTION
## #️⃣ 기능 설명
> 장소 저장된 카테고리 삭제 후 재저장 시도 시 제대로 저장될 수 있도록 수정

## 🛠️ 작업 상세 내용
- [x] PlaceCommandServiceImpl: 중복 저장 검사를 멤버의 활성 카테고리 단위로 상향해, 동일 멤버가 같은 장소를 여러 카테고리에 중복 저장하지 못하게 수정(이전 existsByPlace(place) 제거) -> 저장돼 있던 카테고리를 삭제 후에는 동일 장소를 다른 카테고리에 정상 저장 가능, 활성 카테고리 간 중복 저장은 차단

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
