### PR TITLE
♻️ [Refactor] 온보딩 로직 복귀 및 닉네임 검증 api 추가

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -19,7 +19,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 멤버 관련 에러
     MEMBER_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4001", "사용자가 없습니다."),
     NICKNAME_NOT_EXIST(HttpStatus.BAD_REQUEST, "MEMBER4002", "닉네임은 필수입니다."),
-    ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "이미 존재하는 사용자입니다. 온보딩을 마치지 않았습니다."),
+    ONBOARDING_NOT_COMPLETED(HttpStatus.BAD_REQUEST, "MEMBER4003", "온보딩을 마치지 않았습니다."),
     INVALID_REGION_COUNT(HttpStatus.BAD_REQUEST, "MEMBER4004", "좋아하는 동네는 최소 1개, 최대 3개까지 선택할 수 있습니다."),
     SOCIALID_NOT_FOUND(HttpStatus.BAD_REQUEST, "MEMBER4005", "socialId가 없습니다."),
     INVALID_IMAGE_TYPE(HttpStatus.BAD_REQUEST, "IMAGE4006", "이미지 형식의 파일만 업로드할 수 있습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -15,7 +15,7 @@ public enum SuccessStatus implements BaseCode {
     // 멤버 관련 응답
     MEMBER_NEEDS_ONBOARDING(HttpStatus.CREATED, "MEMBER2001", "신규 유저입니다. 온보딩이 필요합니다."),
     MEMBER_ALREADY_LOGIN(HttpStatus.OK, "MEMBER2002", "이미 등록된 유저입니다."),
-    MEMBER_ONBOARDING_SUCCESS(HttpStatus.CREATED, "MEMBER2003", "온보딩 정보를 저장했습니다."),
+    MEMBER_ONBOARDING_SUCCESS(HttpStatus.CREATED, "MEMBER2003", "온보딩 정보를 성공적으로 저장했습니다."),
     MEMBER_INFO_READ_SUCCESS(HttpStatus.OK, "MEMBER2004", "유저 정보를 성공적으로 조회했습니다."),
     MEMBER_LOGOUT_SUCCESS(HttpStatus.OK, "MEMBER2005", "로그아웃이 완료되었습니다."),
     MEMBER_DELETE_SUCCESS(HttpStatus.NO_CONTENT, "MEMBER2006", "회원 탈퇴가 완료되었습니다."),

--- a/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/SuccessStatus.java
@@ -24,6 +24,7 @@ public enum SuccessStatus implements BaseCode {
     MEMBER_REGION_UPDATE_SUCCESS(HttpStatus.OK, "MEMBER2009", "관심 동네가 성공적으로 변경되었습니다."),
     MEMBER_PROFILE_IMAGE_UPDATE_SUCCESS(HttpStatus.OK, "MEMBER2010", "프로필 이미지가 성공적으로 변경되었습니다."),
     MEMBER_ALREADY_ONBOARDING_COMPLETED(HttpStatus.OK, "MEMBER2011", "온보딩이 이미 완료된 유저입니다."),
+    MEMBER_NICKNAME_CHECK_COMPLETED(HttpStatus.OK, "MEMBER2011", "사용 가능한 닉네임입니다."),
 
     // 장소 저장 관련 응답
     SAVED_PLACE_CREATE_SUCCESS(HttpStatus.CREATED, "SAVE_PLACE2001", "장소가 카테고리에 성공적으로 저장되었습니다."),

--- a/src/main/java/DNBN/spring/converter/MemberConverter.java
+++ b/src/main/java/DNBN/spring/converter/MemberConverter.java
@@ -22,6 +22,7 @@ public class MemberConverter {
         return MemberResponseDTO.OnboardingResultDTO.builder()
                 .memberId(member.getId())
                 .nickname(member.getNickname())
+                .profileImage(member.getProfileImage() != null ? member.getProfileImage().getImageUrl() : null)
                 .chosenRegionIds(
                         member.getLikeRegionList().stream()
                                 .map(lp -> lp.getRegion().getId())
@@ -54,6 +55,7 @@ public class MemberConverter {
 //                .profileImage(member.getProfileImage().getImageUrl())
                 .profileImage(profileImageUrl)
                 .likeRegions(likeRegions)
+                .isOnboardingCompleted(member.isOnboardingCompleted())
                 .build();
     }
 }

--- a/src/main/java/DNBN/spring/converter/MemberConverter.java
+++ b/src/main/java/DNBN/spring/converter/MemberConverter.java
@@ -32,7 +32,7 @@ public class MemberConverter {
                 .build();
     }
 
-    public static MemberResponseDTO.MemberInfoDTO toMemberInfoDTO(Member member) {
+    public static MemberResponseDTO.MemberInfoDTO toMemberInfoDTO(Member member, boolean isOnboardingCompleted) {
         List<RegionResponseDTO.RegionPreviewnDTO> likeRegions = member.getLikeRegionList()
                 .stream()
                 .map(lp -> {
@@ -55,7 +55,8 @@ public class MemberConverter {
 //                .profileImage(member.getProfileImage().getImageUrl())
                 .profileImage(profileImageUrl)
                 .likeRegions(likeRegions)
-                .isOnboardingCompleted(member.isOnboardingCompleted())
+//                .isOnboardingCompleted(member.isOnboardingCompleted())
+                .isOnboardingCompleted(isOnboardingCompleted)
                 .build();
     }
 }

--- a/src/main/java/DNBN/spring/repository/MemberRepository/MemberRepository.java
+++ b/src/main/java/DNBN/spring/repository/MemberRepository/MemberRepository.java
@@ -7,5 +7,5 @@ import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findBySocialId(String socialId);
-    boolean existsByNickname(String nickname);
+    boolean existsByNicknameAndIdNot(String nickname, Long memberId);
 }

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 public interface MemberCommandService {
     Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage);
+    MemberResponseDTO.NicknameCheckResultDTO checkNickname(Long memberId, String nickname);
     void logout(HttpServletResponse response, Long memberId);
     void deleteMember(Long memberId);
     MemberResponseDTO.NicknameUpdateResultDTO updateMemberNickname(Long memberId, String newNickname);

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandService.java
@@ -1,6 +1,7 @@
 package DNBN.spring.service.MemberService;
 
 import DNBN.spring.domain.Member;
+import DNBN.spring.web.dto.request.MemberRequestDTO;
 import DNBN.spring.web.dto.response.MemberResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.web.multipart.MultipartFile;
@@ -8,7 +9,7 @@ import org.springframework.web.multipart.MultipartFile;
 import java.util.List;
 
 public interface MemberCommandService {
-    Member onboardingMember(Long memberId);
+    Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage);
     void logout(HttpServletResponse response, Long memberId);
     void deleteMember(Long memberId);
     MemberResponseDTO.NicknameUpdateResultDTO updateMemberNickname(Long memberId, String newNickname);

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -7,6 +7,7 @@ import DNBN.spring.apiPayload.exception.handler.RegionHandler;
 import DNBN.spring.aws.s3.AmazonS3Manager;
 import DNBN.spring.converter.MemberConverter;
 import DNBN.spring.domain.Member;
+import DNBN.spring.domain.ProfileImage;
 import DNBN.spring.domain.Region;
 import DNBN.spring.domain.Uuid;
 import DNBN.spring.domain.mapping.LikeRegion;
@@ -86,7 +87,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
             String pictureUrl = s3Manager.uploadFile(s3Manager.generateMemberKeyName(savedUuid), profileImage);
 
-            profileImageRepository.save(MemberConverter.toProfileImage(pictureUrl, member));
+            ProfileImage savedImage = profileImageRepository.save(MemberConverter.toProfileImage(pictureUrl, member));
+            member.setProfileImage(savedImage);
         }
 
         likeRegionRepository.saveAll( // 좋아하는 동네 연결
@@ -242,47 +244,39 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-//        if (profileImage == null || profileImage.isEmpty()) {
-//            throw new MemberHandler(ErrorStatus._BAD_REQUEST);
-//        }
+        if (profileImage == null || profileImage.isEmpty()) {
+            throw new MemberHandler(ErrorStatus._BAD_REQUEST);
+        }
 
-        String profileImageUrl = null;
+        // 파일 형식 검사
+        String contentType = profileImage.getContentType();
+        if (contentType == null || !contentType.startsWith("image/")) {
+            throw new MemberHandler(ErrorStatus.INVALID_IMAGE_TYPE);
+        }
 
-        if (profileImage != null && !profileImage.isEmpty()) {
-            // 파일 형식 검사
-            String contentType = profileImage.getContentType();
-            if (contentType == null || !contentType.startsWith("image/")) {
-                throw new MemberHandler(ErrorStatus.INVALID_IMAGE_TYPE);
-            }
+        // 파일 용량 제한 (10MB)
+        long maxFileSize = 10 * 1024 * 1024;
+        if (profileImage.getSize() > maxFileSize) {
+            throw new MemberHandler(ErrorStatus.IMAGE_FILE_TOO_LARGE);
+        }
 
-            // 파일 용량 제한 (10MB)
-            long maxFileSize = 10 * 1024 * 1024;
-            if (profileImage.getSize() > maxFileSize) {
-                throw new MemberHandler(ErrorStatus.IMAGE_FILE_TOO_LARGE);
-            }
+        // UUID 생성 후 저장
+        String uuidStr = UUID.randomUUID().toString();
+        Uuid uuid = uuidRepository.save(Uuid.builder().uuid(uuidStr).build());
 
-            // UUID 생성 후 저장
-            String uuid = UUID.randomUUID().toString();
-            Uuid savedUuid = uuidRepository.save(Uuid.builder().uuid(uuid).build());
+        // S3 업로드
+        String profileImageUrl = s3Manager.uploadFile(s3Manager.generateMemberKeyName(uuid), profileImage);
 
-            // S3 업로드
-            profileImageUrl = s3Manager.uploadFile(s3Manager.generateMemberKeyName(savedUuid), profileImage);
+        if (member.getProfileImage() != null) {
+            // 기존 이미지의 키 추출 및 삭제
+            String oldKey = s3Manager.extractS3KeyFromUrl(member.getProfileImage().getImageUrl());
+            s3Manager.deleteFile(oldKey);
 
-            if (member.getProfileImage() != null) {
-                // 기존 이미지의 키 추출 및 삭제
-                String oldKey = s3Manager.extractS3KeyFromUrl(member.getProfileImage().getImageUrl());
-                s3Manager.deleteFile(oldKey);
-
-                // update: 기존 엔티티에 새로운 URL만 set
-                member.getProfileImage().updateImageUrl(profileImageUrl);
-            } else {
-                // 새 이미지 insert
-                profileImageRepository.save(MemberConverter.toProfileImage(profileImageUrl, member));
-            }
-        } else { // 이미지 없을 때는 기존 URL 유지
-            profileImageUrl = member.getProfileImage() != null
-                    ? member.getProfileImage().getImageUrl()
-                    : null;
+            // update: 기존 엔티티에 새로운 URL만 set
+            member.getProfileImage().updateImageUrl(profileImageUrl);
+        } else {
+            // 새 이미지 insert
+            profileImageRepository.save(MemberConverter.toProfileImage(profileImageUrl, member));
         }
 
         return MemberResponseDTO.ProfileImageUpdateResultDTO.builder()

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -204,11 +204,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new MemberHandler(ErrorStatus.INVALID_REGION_COUNT);
         }
 
+        // findRegion() 사용해서 모든 지역 ID 확인 및 조회
+        List<Region> regions = regionIds.stream()
+                .map(this::findRegion)
+                .toList();
+        /*
         // 모든 지역 ID가 존재하는지 확인
         List<Region> regions = regionIds.stream()
                 .map(id -> regionRepository.findById(id)
                         .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND)))
                 .toList();
+        */
 
         // 기존 관심 동네 삭제
         likeRegionRepository.deleteByMember(member);

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -42,7 +42,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private final AmazonS3Manager s3Manager;
     private final UuidRepository uuidRepository;
     private final ProfileImageRepository profileImageRepository;
-    private final OnboardingValidator onboardingValidator;
+//    private final OnboardingValidator onboardingValidator;
 
     @Override
     @Transactional
@@ -62,7 +62,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new MemberHandler(ErrorStatus.NICKNAME_NOT_EXIST);
         }
 
-        validateNicknameDuplicate(request.getNickname());
+        validateNicknameDuplicate(memberId, request.getNickname());
 
         // 좋아하는 동네 개수 최소 1개 ~ 최대 3개
         int chosenRegionCount = request.getChosenRegionIds() == null ? 0 : request.getChosenRegionIds().size();
@@ -115,6 +115,17 @@ public class MemberCommandServiceImpl implements MemberCommandService {
     private Region findRegion(Long regionId) {
         return regionRepository.findById(regionId)
                 .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
+    }
+
+    @Override
+    public MemberResponseDTO.NicknameCheckResultDTO checkNickname(Long memberId, String nickname) {
+
+        validateNicknameDuplicate(memberId, nickname);
+
+        return MemberResponseDTO.NicknameCheckResultDTO.builder()
+                .memberId(memberId)
+                .nickname(nickname)
+                .build();
     }
 
     @Override
@@ -185,7 +196,7 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new MemberHandler(ErrorStatus.NICKNAME_NOT_EXIST);
         }
 
-        validateNicknameDuplicate(newNickname);
+        validateNicknameDuplicate(memberId, newNickname);
 
 //        member.setNickname(newNickname);
         member.updateNickname(newNickname); // 도메인 주도 설계(Domain-Driven Design) 원칙에 부합하도록
@@ -285,8 +296,8 @@ public class MemberCommandServiceImpl implements MemberCommandService {
                 .build();
     }
 
-    private void validateNicknameDuplicate(String nickname) {
-        boolean exists = memberRepository.existsByNickname(nickname);
+    private void validateNicknameDuplicate(Long memberId, String nickname) {
+        boolean exists = memberRepository.existsByNicknameAndIdNot(nickname, memberId);
         if (exists) {
             throw new MemberHandler(ErrorStatus.NICKNAME_DUPLICATE);
         }

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -188,9 +188,9 @@ public class MemberCommandServiceImpl implements MemberCommandService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
-//        if (!member.isOnboardingCompleted()) {
-//            throw new MemberHandler(ErrorStatus.ONBOARDING_NOT_COMPLETED);
-//        }
+        if (!member.isOnboardingCompleted()) {
+            throw new MemberHandler(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+        }
 
         if (newNickname == null || newNickname.trim().isEmpty()) {
             throw new MemberHandler(ErrorStatus.NICKNAME_NOT_EXIST);

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -16,6 +16,7 @@ import DNBN.spring.repository.ProfileImageRepository.ProfileImageRepository;
 import DNBN.spring.repository.RegionRepository.RegionRepository;
 import DNBN.spring.repository.UuidRepository.UuidRepository;
 import DNBN.spring.validation.validator.OnboardingValidator;
+import DNBN.spring.web.dto.request.MemberRequestDTO;
 import DNBN.spring.web.dto.response.MemberResponseDTO;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,6 +28,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 @Slf4j
 @Service
@@ -43,17 +45,74 @@ public class MemberCommandServiceImpl implements MemberCommandService {
 
     @Override
     @Transactional
-    public Member onboardingMember(Long memberId) {
+    @ValidateS3ImageUpload
+    public Member onboardingMember(Long memberId, MemberRequestDTO.OnboardingDTO request, MultipartFile profileImage) {
         // 기존 회원이 존재하는지를 따짐
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
 
+        // 온보딩 완료 여부 체크
+        if (member.isOnboardingCompleted()) {
+            throw new MemberHandler(ErrorStatus.ONBOARDING_NOT_COMPLETED);
+        }
+
+        // 닉네임 null 혹은 빈 문자열 체크
+        if (request.getNickname() == null || request.getNickname().trim().isEmpty()) {
+            throw new MemberHandler(ErrorStatus.NICKNAME_NOT_EXIST);
+        }
+
+        validateNicknameDuplicate(request.getNickname());
+
+        // 좋아하는 동네 개수 최소 1개 ~ 최대 3개
+        int chosenRegionCount = request.getChosenRegionIds() == null ? 0 : request.getChosenRegionIds().size();
+        if (chosenRegionCount < 1 || chosenRegionCount > 3) {
+            throw new MemberHandler(ErrorStatus.INVALID_REGION_COUNT);
+        }
+
+        // 선택한 지역들이 모두 존재하는지 확인
+        for (Long regionId : request.getChosenRegionIds()) {
+            boolean exists = regionRepository.existsById(regionId);
+            if (!exists) {
+                throw new MemberHandler(ErrorStatus.REGION_NOT_FOUND);
+            }
+        }
+
+        member.setNickname(request.getNickname());
+
+        if (profileImage != null && !profileImage.isEmpty()) {
+            String uuid = UUID.randomUUID().toString();
+            Uuid savedUuid = uuidRepository.save(Uuid.builder()
+                    .uuid(uuid).build());
+
+            String pictureUrl = s3Manager.uploadFile(s3Manager.generateMemberKeyName(savedUuid), profileImage);
+
+            profileImageRepository.save(MemberConverter.toProfileImage(pictureUrl, member));
+        }
+
+        likeRegionRepository.saveAll( // 좋아하는 동네 연결
+                request.getChosenRegionIds().stream() // 프론트에서 넘겨준 값
+                        .map(regionId -> LikeRegion.of(member, findRegion(regionId))) // 각 regionId에 대해 LikeRegion.of(member, region)를 호출해서 LikeRegion 객체들 생성
+                        .collect(Collectors.toList()) // 방금 만든 LikeRegion 객체들을 한 번에 DB에 저장
+        );
+
+        member.setOnboardingCompleted(true);
+
+        return member;
+//        return memberRepository.save(member);
+
+        /*
         boolean complete = onboardingValidator.isCompleteOnboarding(member);
         if (complete) {
             member.setOnboardingCompleted(true); // @Transactional에 의해 메서드 종료 시 변경 사항이 DB에 자동 반영
         } // 조건이 충족되지 않으면, member의 isOnboardingCompleted는 기본값(false)인 채로 유지
 
         return member;
+        */
+    }
+
+    private Region findRegion(Long regionId) {
+        return regionRepository.findById(regionId)
+                .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
     }
 
     @Override

--- a/src/main/java/DNBN/spring/service/MemberService/MemberQueryServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberQueryServiceImpl.java
@@ -6,6 +6,7 @@ import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.converter.MemberConverter;
 import DNBN.spring.domain.Member;
 import DNBN.spring.repository.MemberRepository.MemberRepository;
+import DNBN.spring.validation.validator.OnboardingValidator;
 import DNBN.spring.web.dto.response.MemberResponseDTO;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,7 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
     private final MemberRepository memberRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final OnboardingValidator onboardingValidator;
 
     @Override
     @Transactional(readOnly = true)
@@ -26,6 +28,9 @@ public class MemberQueryServiceImpl implements MemberQueryService {
 
         Member member = memberRepository.findById(memberId) // MemberRepository 로부터 사용자 정보를 조회
                 .orElseThrow(()-> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-        return MemberConverter.toMemberInfoDTO(member); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 MemberInfoDTO 로 반환
+
+        boolean complete = onboardingValidator.isCompleteOnboarding(member);
+
+        return MemberConverter.toMemberInfoDTO(member, complete); // 정보 조회에 성공하면, 우리가 정의한 Response DTO인 MemberInfoDTO 로 반환
     }
 }

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -60,7 +60,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.sendRedirect(redirectUri);
         */
 
-        /**/
+        /*
         // JSON 응답 방식 (SPA 등 API 호출용)
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
                 .accessToken(accessToken)
@@ -79,24 +79,24 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
-
+        */
 
         // 쿠키로 프론트에게 내려주기
-//        boolean isOnboardingCompleted = member.isOnboardingCompleted();
-//        SuccessStatus status = isOnboardingCompleted
-//                ? SuccessStatus.MEMBER_ALREADY_ONBOARDING_COMPLETED
-//                : SuccessStatus.MEMBER_NEEDS_ONBOARDING;
-//
-//        // 1. 민감 정보: HttpOnly + Secure 쿠키
-//        addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
-//        addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
-//        addCookie(response, "memberId", String.valueOf(member.getId()), true, 60 * 60 * 4);
-//        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), false, 60 * 60 * 4);
-//
-//        // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
-//        addCookie(response, "isSuccess", "true", false, 60);
-//        addCookie(response, "code", status.getCode(), false, 60);
-//        addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
+        boolean isOnboardingCompleted = member.isOnboardingCompleted();
+        SuccessStatus status = isOnboardingCompleted
+                ? SuccessStatus.MEMBER_ALREADY_ONBOARDING_COMPLETED
+                : SuccessStatus.MEMBER_NEEDS_ONBOARDING;
+
+        // 1. 민감 정보: HttpOnly + Secure 쿠키
+        addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
+        addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
+        addCookie(response, "memberId", String.valueOf(member.getId()), true, 60 * 60 * 4);
+        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), false, 60 * 60 * 4);
+
+        // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
+        addCookie(response, "isSuccess", "true", false, 60);
+        addCookie(response, "code", status.getCode(), false, 60);
+        addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
 
         /*
         // 3. CSRF 토큰 발급 + 쿠키로 내려주기
@@ -125,7 +125,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         clearJsessionCookie(response);
 
         // 4. 리다이렉트 (브릿지 페이지)
-//        response.sendRedirect("https://www.dnbn.site/oauth-redirect");
+        response.sendRedirect("https://www.dnbn.site/oauth-redirect");
     }
 
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -60,7 +60,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.sendRedirect(redirectUri);
         */
 
-        /*
+        /**/
         // JSON 응답 방식 (SPA 등 API 호출용)
         AuthResponseDTO.LoginResultDTO result = AuthResponseDTO.LoginResultDTO.builder()
                 .accessToken(accessToken)
@@ -79,24 +79,24 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_OK);
         response.getWriter().write(objectMapper.writeValueAsString(apiResponse));
-        */
+
 
         // 쿠키로 프론트에게 내려주기
-        boolean isOnboardingCompleted = member.isOnboardingCompleted();
-        SuccessStatus status = isOnboardingCompleted
-                ? SuccessStatus.MEMBER_ALREADY_ONBOARDING_COMPLETED
-                : SuccessStatus.MEMBER_NEEDS_ONBOARDING;
-
-        // 1. 민감 정보: HttpOnly + Secure 쿠키
-        addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
-        addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
-        addCookie(response, "memberId", String.valueOf(member.getId()), true, 60 * 60 * 4);
-        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), false, 60 * 60 * 4);
-
-        // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
-        addCookie(response, "isSuccess", "true", false, 60);
-        addCookie(response, "code", status.getCode(), false, 60);
-        addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
+//        boolean isOnboardingCompleted = member.isOnboardingCompleted();
+//        SuccessStatus status = isOnboardingCompleted
+//                ? SuccessStatus.MEMBER_ALREADY_ONBOARDING_COMPLETED
+//                : SuccessStatus.MEMBER_NEEDS_ONBOARDING;
+//
+//        // 1. 민감 정보: HttpOnly + Secure 쿠키
+//        addCookie(response, "accessToken", accessToken, true, 60 * 60 * 4); // 4시간
+//        addCookie(response, "refreshToken", refreshToken, true, 60 * 60 * 24 * 7); // 7일
+//        addCookie(response, "memberId", String.valueOf(member.getId()), true, 60 * 60 * 4);
+//        addCookie(response, "isOnboardingCompleted", String.valueOf(isOnboardingCompleted), false, 60 * 60 * 4);
+//
+//        // 2. 상태 정보: HttpOnly = false (JS에서 읽게)
+//        addCookie(response, "isSuccess", "true", false, 60);
+//        addCookie(response, "code", status.getCode(), false, 60);
+//        addCookie(response, "message", URLEncoder.encode(status.getMessage(), StandardCharsets.UTF_8), false, 60);
 
         /*
         // 3. CSRF 토큰 발급 + 쿠키로 내려주기
@@ -125,7 +125,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         clearJsessionCookie(response);
 
         // 4. 리다이렉트 (브릿지 페이지)
-        response.sendRedirect("https://www.dnbn.site/oauth-redirect");
+//        response.sendRedirect("https://www.dnbn.site/oauth-redirect");
     }
 
     private void addCookie(HttpServletResponse response, String name, String value, boolean httpOnly, int maxAgeInSeconds) {

--- a/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
+++ b/src/main/java/DNBN/spring/service/OAuth2/OAuth2SuccessHandler.java
@@ -1,8 +1,10 @@
 package DNBN.spring.service.OAuth2;
 
+import DNBN.spring.apiPayload.ApiResponse;
 import DNBN.spring.apiPayload.code.status.SuccessStatus;
 import DNBN.spring.config.security.jwt.JwtTokenProvider;
 import DNBN.spring.domain.Member;
+import DNBN.spring.web.dto.response.AuthResponseDTO;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletResponse;

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -30,17 +30,24 @@ public class MemberRestController {
     private final MemberQueryService memberQueryService;
     private final MemberCommandService memberCommandService;
 
-    @PostMapping(value = "/onboarding")
+    @PostMapping(
+            value = "/onboarding",
+            consumes = {MediaType.MULTIPART_FORM_DATA_VALUE}
+    )
     @Operation(
             summary = "회원 초기 정보 등록 (온보딩) API - JWT AccessToken 인증 필요",
-            description = "JWT 인증된 멤버가 닉네임, 선호 지역을 등록하는 API입니다.",
+            description = "JWT 인증된 멤버가 닉네임, 프로필 이미지, 선호 지역을 등록하는 API입니다.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
-    public ResponseEntity<ApiResponse<MemberResponseDTO.OnboardingResultDTO>> onboard(@AuthenticationPrincipal MemberDetails memberDetails) {
+    public ApiResponse<MemberResponseDTO.OnboardingResultDTO> onboard(
+            @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestPart("request") @Valid MemberRequestDTO.OnboardingDTO request,
+            @RequestPart(value = "profileImage", required = false) MultipartFile profileImage
+    ) {
         Long memberId = memberDetails.getMember().getId();
-        Member member = memberCommandService.onboardingMember(memberId);
-        return ResponseEntity.status(SuccessStatus.MEMBER_ONBOARDING_SUCCESS.getHttpStatus())
-                .body(ApiResponse.of(SuccessStatus.MEMBER_ONBOARDING_SUCCESS, MemberConverter.toOnboardingResponseDTO(member)));
+        Member member = memberCommandService.onboardingMember(memberId, request, profileImage);
+        return ApiResponse.onSuccess(MemberConverter.toOnboardingResponseDTO(member));
     }
 
     @GetMapping("/info")

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -39,7 +39,7 @@ public class MemberRestController {
             description = "JWT 인증된 멤버가 닉네임, 프로필 이미지, 선호 지역을 등록하는 API입니다.",
             security = @SecurityRequirement(name = "JWT TOKEN")
     )
-    public ApiResponse<MemberResponseDTO.OnboardingResultDTO> onboard(
+    public ResponseEntity<ApiResponse<MemberResponseDTO.OnboardingResultDTO>> onboard(
             @Parameter(content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE))
             @AuthenticationPrincipal MemberDetails memberDetails,
             @RequestPart("request") @Valid MemberRequestDTO.OnboardingDTO request,
@@ -47,7 +47,8 @@ public class MemberRestController {
     ) {
         Long memberId = memberDetails.getMember().getId();
         Member member = memberCommandService.onboardingMember(memberId, request, profileImage);
-        return ApiResponse.onSuccess(MemberConverter.toOnboardingResponseDTO(member));
+        return ResponseEntity.status(SuccessStatus.MEMBER_ONBOARDING_SUCCESS.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.MEMBER_ONBOARDING_SUCCESS, MemberConverter.toOnboardingResponseDTO(member)));
     }
 
     @GetMapping("/info")

--- a/src/main/java/DNBN/spring/web/controller/MemberRestController.java
+++ b/src/main/java/DNBN/spring/web/controller/MemberRestController.java
@@ -51,6 +51,21 @@ public class MemberRestController {
                 .body(ApiResponse.of(SuccessStatus.MEMBER_ONBOARDING_SUCCESS, MemberConverter.toOnboardingResponseDTO(member)));
     }
 
+    @PostMapping("/check-nickname")
+    @Operation(summary = "닉네임 검증 API - JWT AccessToken 인증 필요",
+            description = "이미 존재하는 닉네임인지 검증하는 API입니다.",
+            security = { @SecurityRequirement(name = "JWT TOKEN") }
+    )
+    public ResponseEntity<ApiResponse<MemberResponseDTO.NicknameCheckResultDTO>> checkNickname(
+            @AuthenticationPrincipal MemberDetails memberDetails,
+            @RequestBody @Valid MemberRequestDTO.NicknameCheckDTO request
+    ) {
+        Long memberId = memberDetails.getMember().getId();
+        MemberResponseDTO.NicknameCheckResultDTO response = memberCommandService.checkNickname(memberId, request.getNickname());
+        return ResponseEntity.status(SuccessStatus.MEMBER_NICKNAME_CHECK_COMPLETED.getHttpStatus())
+                .body(ApiResponse.of(SuccessStatus.MEMBER_NICKNAME_CHECK_COMPLETED, response));
+    }
+
     @GetMapping("/info")
     @Operation(summary = "회원 정보 조회 API - JWT AccessToken 인증 필요",
             description = "JWT 인증된 멤버가 자신의 정보를 조회하는 API입니다.",

--- a/src/main/java/DNBN/spring/web/dto/request/MemberRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/request/MemberRequestDTO.java
@@ -16,6 +16,7 @@ public class MemberRequestDTO {
     @Setter
     public static class OnboardingDTO {
         @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
         String nickname;
 
 //        String profileImage;

--- a/src/main/java/DNBN/spring/web/dto/request/MemberRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/request/MemberRequestDTO.java
@@ -15,8 +15,8 @@ public class MemberRequestDTO {
     @Getter
     @Setter
     public static class OnboardingDTO {
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(max = 10, message = "닉네임은 최대 10자입니다.")
         String nickname;
 
 //        String profileImage;
@@ -28,9 +28,17 @@ public class MemberRequestDTO {
 
     @Getter
     @Setter
+    public static class NicknameCheckDTO {
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(max = 10, message = "닉네임은 최대 10자입니다.")
+        String nickname;
+    }
+
+    @Getter
+    @Setter
     public static class NicknameUpdateDTO {
-        @NotBlank(message = "닉네임은 필수입니다.")
-        @Size(max = 10, message = "닉네임은 최대 10자까지 가능합니다.")
+        @NotBlank(message = "닉네임을 입력해주세요.")
+        @Size(max = 10, message = "닉네임은 최대 10자입니다.")
         String nickname;
     }
 

--- a/src/main/java/DNBN/spring/web/dto/response/MemberResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/response/MemberResponseDTO.java
@@ -12,6 +12,7 @@ public class MemberResponseDTO {
     public static class OnboardingResultDTO {
         private Long memberId;
         private String nickname;
+        String profileImage;
         private List<Long> chosenRegionIds;
         private Boolean isOnboardingCompleted;
     }
@@ -25,6 +26,7 @@ public class MemberResponseDTO {
         String nickname;
         String profileImage;
         List<RegionResponseDTO.RegionPreviewnDTO> likeRegions;
+        private Boolean isOnboardingCompleted;
     }
 
     @Getter

--- a/src/main/java/DNBN/spring/web/dto/response/MemberResponseDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/response/MemberResponseDTO.java
@@ -21,6 +21,15 @@ public class MemberResponseDTO {
     @Builder
     @NoArgsConstructor
     @AllArgsConstructor
+    public static class NicknameCheckResultDTO {
+        private Long memberId;
+        private String nickname;
+    }
+
+    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class MemberInfoDTO {
         Long memberId;
         String nickname;

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: ${KAKAO_REDIRECT_URL}
+            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -43,7 +43,7 @@ spring:
             client-authentication-method: client_secret_post
             client-id: ${KAKAO_CLIENT_ID}
             client-secret: ${KAKAO_SECRET}
-            redirect-uri: http://localhost:8080/login/oauth2/code/kakao
+            redirect-uri: ${KAKAO_REDIRECT_URL}
             authorization-grant-type: authorization_code
             scope:
             client-name: Kakao


### PR DESCRIPTION
## #️⃣ 기능 설명
> 이슈에 적음

## 🛠️ 작업 상세 내용
- [x] 분리했던 온보딩 로직 다시 합침(예전 코드와 동일)
- [x] 닉네임 검증 API 추가(자신의 닉네임은 허용하도록, 예를 들어 마이페이지에서 닉네임 변경 시 본인의 닉네임을 입력했을 때 사용할 수 없다고 뜨지 않도록)
- [x] 닉네임 변경 api에서 findRegion사용해서 리팩토링
- [x] 유저 정보 조회에 검증 온보딩에서 사용하던 로직 추가함(결과는 같음)
- [x] "닉네임을 입력해주세요.", "닉네임은 최대 10자입니다." 등 피그마와 동일하게 수정
- [x] 닉네임 변경에서 온보딩 여부 체크해서 온보딩 안 마쳤는데 닉네임 변경 시도하면 "온보딩을 마치지 않았습니다."라고 보임 (기존 코드로 복귀)

## 📸 스크린샷 (선택)
POST
 /api/member/check-nickname 닉네임 검증 API - JWT AccessToken 인증 필요

닉네임 빈 값이면(null이면)
<img width="396" height="231" alt="image" src="https://github.com/user-attachments/assets/1c58882d-9220-46d1-bd94-787e0931968c" />

10자 초과하면
<img width="402" height="240" alt="image" src="https://github.com/user-attachments/assets/0db367d7-d58d-4280-9a16-352e696b4a62" />

이미 사용 중인 닉네임이면
<img width="456" height="198" alt="image" src="https://github.com/user-attachments/assets/3f70a68b-8090-4ff4-ad00-508621ef93b3" />

검증에 성공하면
<img width="443" height="229" alt="image" src="https://github.com/user-attachments/assets/8dcccf8c-f704-4389-b921-e09f35e36dcb" />

온보딩에서 jk라는 닉네임 등록 후 닉네임 검증해보면 자기 닉네임은 사용 가능하도록 뜬다
<img width="441" height="222" alt="image" src="https://github.com/user-attachments/assets/f754bfba-77cf-45be-94a1-0534d35452fc" />

## 💬 기타(공유사항 to 리뷰어)
테스트해보고 싶으시면 refactor/genie/228에서 해보시면 됩니다!

혹시 궁금하실까봐... 아래처럼 하시면 됩니다!
1. 디비의 멤버 테이블에서 자신의 카카오 row 삭제
2. application.yml에서 ${KAKAO_REDIRECT_URL}을 아래처럼 수정
http://localhost:8080/login/oauth2/code/kakao
3. 성공핸들러에서 // JSON 응답 방식 (SPA 등 API 호출용) <-- 주석 해제
// 쿠키로 프론트에게 내려주기 <-- 주석 처리

그리고 run 한 다음에 테스트해보심 됩니다