### PR TITLE
♻️ [Refactor] ArticleCommandServiceImpl 클린 코드 리팩토링

### DIFF
--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -40,6 +40,8 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class ArticleCommandServiceImpl implements ArticleCommandService {
 
+    private static final String PIN_CATEGORY_UPPERCASE = "toUpperCase";
+
     private final ArticleRepository articleRepository;
     private final ArticlePhotoRepository articlePhotoRepository;
     private final MemberRepository memberRepository;
@@ -63,18 +65,10 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         Place place = getPlace(request.placeId());
         Region region = getRegion(request.regionId());
 
-        place.updateTitle(request.placeName());
-        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
-
-        titleLengthValidator.validateArticleTitle(request.title());
-        contentLengthValidator.validateArticleContent(request.content());
-
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        return new ArticleWithPhotos(article, savedPhotos);
+        updatePlaceInfo(place, request);
+        validateArticleContent(request);
+        
+        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
     }
 
     @Override
@@ -83,11 +77,74 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     public ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
-        Region region    = getRegion(request.regionId());
+        Region region = getRegion(request.regionId());
 
+        validateArticleContent(request);
+        Place place = createAndSaveNewPlace(request, region);
+        
+        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
+    }
+
+    @Override
+    @ValidateS3ImageUpload
+    @ValidateArticle
+    public ArticleWithPhotos updateArticle(Long memberId, Long articleId, ArticleUpdateRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        Article article = getArticle(articleId);
+
+        updateArticleAndPlace(article, request);
+        updateArticleImages(article, mainImage, imageFiles);
+
+        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
+        return new ArticleWithPhotos(article, photos);
+    }
+
+    @Override
+    @ValidateArticle
+    public void deleteArticle(Long memberId, Long articleId) {
+        Article article = getArticle(articleId);
+        article.delete();
+    }
+
+    private void updatePlaceInfo(Place place, ArticleRequestDTO request) {
+        place.updateTitle(request.placeName());
+        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
+    }
+
+    private void validateArticleContent(ArticleRequestDTO request) {
         titleLengthValidator.validateArticleTitle(request.title());
         contentLengthValidator.validateArticleContent(request.content());
+    }
 
+    private void validateArticleContent(ArticleWithLocationRequestDTO request) {
+        titleLengthValidator.validateArticleTitle(request.title());
+        contentLengthValidator.validateArticleContent(request.content());
+    }
+
+    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
+            ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        
+        return new ArticleWithPhotos(article, savedPhotos);
+    }
+
+    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
+            ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        
+        return new ArticleWithPhotos(article, savedPhotos);
+    }
+
+    private Place createAndSaveNewPlace(ArticleWithLocationRequestDTO request, Region region) {
         Place place = Place.builder()
                 .region(region)
                 .latitude(request.latitude())
@@ -97,66 +154,62 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
                 .pinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()))
                 .build();
 
-        place = placeRepository.save(place);
+        return placeRepository.save(place);
+    }
 
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
+    private void updateArticleAndPlace(Article article, ArticleUpdateRequestDTO request) {
+        articleUpdater.updateArticleEntity(article, request);
+        placeUpdater.updatePlaceEntity(article.getPlace(), request);
+    }
 
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        return new ArticleWithPhotos(article, savedPhotos);
+    private void updateArticleImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        if (!hasNewImages(mainImage, imageFiles)) {
+            return;
+        }
+
+        deleteExistingImages(article);
+        uploadNewImages(article, mainImage, imageFiles);
+    }
+
+    private boolean hasNewImages(MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        return (mainImage != null && !mainImage.isEmpty()) || 
+               (imageFiles != null && !imageFiles.isEmpty());
+    }
+
+    private void deleteExistingImages(Article article) {
+        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
+        for (ArticlePhoto photo : photos) {
+            s3Manager.deleteFile(photo.getFileKey());
+            articlePhotoRepository.delete(photo);
+        }
+    }
+
+    private void uploadNewImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
     }
 
     private Member getMember(Long memberId) {
         return memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
     }
+
     private Category getCategory(Long categoryId) {
         return categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
     }
+
     private Place getPlace(Long placeId) {
         return placeRepository.findById(placeId)
                 .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
     }
+
     private Region getRegion(Long regionId) {
         return regionRepository.findById(regionId)
                 .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
     }
 
-    @Override
-    @ValidateS3ImageUpload
-    @ValidateArticle
-    public ArticleWithPhotos updateArticle(Long memberId, Long articleId, ArticleUpdateRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        Article article = getArticle(articleId);
-
-        articleUpdater.updateArticleEntity(article, request);
-        placeUpdater.updatePlaceEntity(article.getPlace(), request);
-
-        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
-        // 새로운 이미지가 제공된 경우, 기존 이미지 삭제 후 새로 추가
-        if ((mainImage != null && !mainImage.isEmpty()) || (imageFiles != null && !imageFiles.isEmpty())) {
-            for (ArticlePhoto photo : photos) {
-                s3Manager.deleteFile(photo.getFileKey());
-                articlePhotoRepository.delete(photo);
-            }
-
-            articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
-            photos = articlePhotoRepository.findAllByArticle(article);
-        }
-
-        return new ArticleWithPhotos(article, photos);
-    }
-
     private Article getArticle(Long articleId) {
         return articleRepository.findById(articleId)
-            .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
-    }
-
-    @Override
-    @ValidateArticle
-    public void deleteArticle(Long memberId, Long articleId) {
-        Article article = getArticle(articleId);
-        article.delete(); // dirty checking
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> `ArticleCommandServiceImpl` 클린 코드 리팩토링 (중복 로직 제거 및 메서드 분리)

## 🛠 작업 항목
- [x] 중복 로직 제거: `createArticleInternal `메서드로 공통 로직 통합
- [x] 메서드 분리: 단일 책임 원칙 적용하여 각 메서드의 책임 명확화
- [x] 가독성 향상: 긴 메서드를 작은 단위로 분해
- [x] 타입 안전성: Object 타입 대신 DTO 타입 사용으로 컴파일 타임 안전성 확보
- [x] 메서드 길이 단축: `updateArticle` 5줄로 단축
- [x] 이미지 처리 로직 분리: `hasNewImages`, `deleteExistingImages`, `uploadNewImages`로 세분화

## 💬 기타(공유사항 to 리뷰어)
- #234 
  - **테스트 코드가 다음 pr에 포함되어있습니다.**
- 기존 기능은 유지하면서 내부 구조만 개선했습니다.
- 메서드 분리 시 타입 안전성을 위해 오버로딩을 사용했습니다. (`validateArticleContent`, `createArticleInternal`)

## ✏️ 추후 개선 필요한 부분
- `ArticleFactory`의 `create` 메서드들을 제네릭으로 통합하여 중복 제거 고려
- 오버로딩된 private helper 메서드들을 제네릭으로 통합하여 중복 제거 고려
  - `validateArticleContent` 메서드 2개 → 제네릭으로 통합
  - `createArticleInternal` 메서드 2개 → 제네릭으로 통합
- 이미지 처리 로직을 `ArticleImageService`로 분리