### PR TITLE
🔨 [Fix] 충돌로 인한 deleteArticle와 updateArticle 메서드 중복 제거

### DIFF
--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -208,33 +208,6 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
                 .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
     }
 
-    @Override
-    @ValidateS3ImageUpload
-    @ValidateArticle
-    public ArticleWithPhotos updateArticle(Long memberId, Long articleId, ArticleUpdateRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        Article article = getArticle(articleId);
-        
-        validateArticleOwner(article, memberId);
-        validateArticleNotDeleted(article);
-
-        articleUpdater.updateArticleEntity(article, request);
-        placeUpdater.updatePlaceEntity(article.getPlace(), request);
-
-        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
-        // 새로운 이미지가 제공된 경우, 기존 이미지 삭제 후 새로 추가
-        if ((mainImage != null && !mainImage.isEmpty()) || (imageFiles != null && !imageFiles.isEmpty())) {
-            for (ArticlePhoto photo : photos) {
-                s3Manager.deleteFile(photo.getFileKey());
-                articlePhotoRepository.delete(photo);
-            }
-
-            articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
-            photos = articlePhotoRepository.findAllByArticle(article);
-        }
-
-        return new ArticleWithPhotos(article, photos);
-    }
-
     private Article getArticle(Long articleId) {
         return articleRepository.findById(articleId)
             .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
@@ -246,21 +219,9 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         }
     }
 
-    // 삭제된 게시물 검증 메서드 추가
     private void validateArticleNotDeleted(Article article) {
         if (article.isDeleted()) {
             throw new RuntimeException("이미 삭제된 게시물입니다.");
         }
-    }
-
-    @Override
-    @ValidateArticle
-    public void deleteArticle(Long memberId, Long articleId) {
-        Article article = getArticle(articleId);
-        
-        validateArticleOwner(article, memberId);
-        validateArticleNotDeleted(article);
-        
-        article.delete(); // dirty checking
     }
 }


### PR DESCRIPTION
## #️⃣ 기능 설명
> 충돌로 인한 deleteArticle와 updateArticle 메서드 중복 제거

## 🛠️ 작업 상세 내용
- [x] deleteArticle, updateArticle 메서드 정리 및 리팩토링 전 메서드 삭제

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
