### PR TITLE
🔨 [Fix] 게시물 생성 요청의 regionId 필드 제거 (미등록 장소 포함)

### DIFF
--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryCustom.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryCustom.java
@@ -6,4 +6,9 @@ import java.util.List;
 
 public interface RegionRepositoryCustom {
     List<Region> searchByKeyword(String keyword, Long cursor, int limit);
+    
+    /**
+     * 위도/경도로 가장 가까운 지역을 찾습니다.
+     */
+    Region findRegionByCoordinates(Double latitude, Double longitude);
 }

--- a/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryImpl.java
+++ b/src/main/java/DNBN/spring/repository/RegionRepository/RegionRepositoryImpl.java
@@ -38,4 +38,12 @@ public class RegionRepositoryImpl implements RegionRepositoryCustom {
                 .limit(limit)
                 .fetch();
     }
+    
+    @Override
+    public Region findRegionByCoordinates(Double latitude, Double longitude) {
+        // TODO: 위경도 기반 지역을 검색 로직 구현 (현재는 임의 지역 반환)
+        return jpaQueryFactory.selectFrom(region)
+                .orderBy(region.id.asc())
+                .fetchFirst();
+    }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -40,8 +40,6 @@ import org.springframework.web.multipart.MultipartFile;
 @Transactional
 public class ArticleCommandServiceImpl implements ArticleCommandService {
 
-    private static final String PIN_CATEGORY_UPPERCASE = "toUpperCase";
-
     private final ArticleRepository articleRepository;
     private final ArticlePhotoRepository articlePhotoRepository;
     private final MemberRepository memberRepository;
@@ -63,12 +61,20 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
         Place place = getPlace(request.placeId());
-        Region region = getRegion(request.regionId());
+        Region region = place.getRegion();
 
-        updatePlaceInfo(place, request);
-        validateArticleContent(request);
-        
-        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
+        place.updateTitle(request.placeName());
+        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
+
+        titleLengthValidator.validateArticleTitle(request.title());
+        contentLengthValidator.validateArticleContent(request.content());
+
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        return new ArticleWithPhotos(article, savedPhotos);
     }
 
     @Override
@@ -77,12 +83,49 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     public ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
-        Region region = getRegion(request.regionId());
+        Region region = findRegionByCoordinates(request.latitude(), request.longitude());
 
-        validateArticleContent(request);
-        Place place = createAndSaveNewPlace(request, region);
-        
-        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
+        titleLengthValidator.validateArticleTitle(request.title());
+        contentLengthValidator.validateArticleContent(request.content());
+
+        Place place = Place.builder()
+            .region(region)
+            .latitude(request.latitude())
+            .longitude(request.longitude())
+            .title(request.placeName())
+            .address(request.detailAddress())
+            .pinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()))
+            .build();
+
+        place = placeRepository.save(place);
+
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        return new ArticleWithPhotos(article, savedPhotos);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+    private Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+            .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+    }
+    private Place getPlace(Long placeId) {
+        return placeRepository.findById(placeId)
+            .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+    }
+    private Region getRegion(Long regionId) {
+        return regionRepository.findById(regionId)
+            .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
+    }
+
+    private Region findRegionByCoordinates(Double latitude, Double longitude) {
+        return regionRepository.findRegionByCoordinates(latitude, longitude);
     }
 
     @Override
@@ -91,121 +134,25 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     public ArticleWithPhotos updateArticle(Long memberId, Long articleId, ArticleUpdateRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Article article = getArticle(articleId);
 
-        updateArticleAndPlace(article, request);
-        updateArticleImages(article, mainImage, imageFiles);
+        validateArticleOwner(article, memberId);
+        validateArticleNotDeleted(article);
 
-        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
-        return new ArticleWithPhotos(article, photos);
-    }
-
-    @Override
-    @ValidateArticle
-    public void deleteArticle(Long memberId, Long articleId) {
-        Article article = getArticle(articleId);
-        article.delete();
-    }
-
-    private void updatePlaceInfo(Place place, ArticleRequestDTO request) {
-        place.updateTitle(request.placeName());
-        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
-    }
-
-    private void validateArticleContent(ArticleRequestDTO request) {
-        titleLengthValidator.validateArticleTitle(request.title());
-        contentLengthValidator.validateArticleContent(request.content());
-    }
-
-    private void validateArticleContent(ArticleWithLocationRequestDTO request) {
-        titleLengthValidator.validateArticleTitle(request.title());
-        contentLengthValidator.validateArticleContent(request.content());
-    }
-
-    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
-            ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        
-        return new ArticleWithPhotos(article, savedPhotos);
-    }
-
-    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
-            ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        
-        return new ArticleWithPhotos(article, savedPhotos);
-    }
-
-    private Place createAndSaveNewPlace(ArticleWithLocationRequestDTO request, Region region) {
-        Place place = Place.builder()
-                .region(region)
-                .latitude(request.latitude())
-                .longitude(request.longitude())
-                .title(request.placeName())
-                .address(request.detailAddress())
-                .pinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()))
-                .build();
-
-        return placeRepository.save(place);
-    }
-
-    private void updateArticleAndPlace(Article article, ArticleUpdateRequestDTO request) {
         articleUpdater.updateArticleEntity(article, request);
         placeUpdater.updatePlaceEntity(article.getPlace(), request);
-    }
 
-    private void updateArticleImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        if (!hasNewImages(mainImage, imageFiles)) {
-            return;
-        }
-
-        deleteExistingImages(article);
-        uploadNewImages(article, mainImage, imageFiles);
-    }
-
-    private boolean hasNewImages(MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        return (mainImage != null && !mainImage.isEmpty()) || 
-               (imageFiles != null && !imageFiles.isEmpty());
-    }
-
-    private void deleteExistingImages(Article article) {
         List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
-        for (ArticlePhoto photo : photos) {
-            s3Manager.deleteFile(photo.getFileKey());
-            articlePhotoRepository.delete(photo);
+        // 새로운 이미지가 제공된 경우, 기존 이미지 삭제 후 새로 추가
+        if ((mainImage != null && !mainImage.isEmpty()) || (imageFiles != null && !imageFiles.isEmpty())) {
+            for (ArticlePhoto photo : photos) {
+                s3Manager.deleteFile(photo.getFileKey());
+                articlePhotoRepository.delete(photo);
+            }
+
+            articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
+            photos = articlePhotoRepository.findAllByArticle(article);
         }
-    }
 
-    private void uploadNewImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-    }
-
-    private Category getCategory(Long categoryId) {
-        return categoryRepository.findById(categoryId)
-                .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
-    }
-
-    private Place getPlace(Long placeId) {
-        return placeRepository.findById(placeId)
-                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-    }
-
-    private Region getRegion(Long regionId) {
-        return regionRepository.findById(regionId)
-                .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
+        return new ArticleWithPhotos(article, photos);
     }
 
     private Article getArticle(Long articleId) {
@@ -223,5 +170,16 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         if (article.isDeleted()) {
             throw new RuntimeException("이미 삭제된 게시물입니다.");
         }
+    }
+
+    @Override
+    @ValidateArticle
+    public void deleteArticle(Long memberId, Long articleId) {
+        Article article = getArticle(articleId);
+
+        validateArticleOwner(article, memberId);
+        validateArticleNotDeleted(article);
+
+        article.delete(); // dirty checking
     }
 }

--- a/src/main/java/DNBN/spring/web/dto/request/ArticleRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/request/ArticleRequestDTO.java
@@ -12,7 +12,6 @@ public record ArticleRequestDTO(
     @NotNull(message = "장소 ID는 필수입니다.") Long placeId,
     @NotBlank(message = "장소명은 필수입니다.") String placeName,
     @NotBlank(message = "핀 카테고리는 필수입니다.") String pinCategory,
-    @NotNull(message = "지역 ID는 필수입니다.") Long regionId,
     @NotBlank(message = "제목은 필수입니다.") String title,
     @NotNull(message = "날짜는 필수입니다.") LocalDate date,
     @NotBlank(message = "내용은 필수입니다.") String content

--- a/src/main/java/DNBN/spring/web/dto/request/ArticleWithLocationRequestDTO.java
+++ b/src/main/java/DNBN/spring/web/dto/request/ArticleWithLocationRequestDTO.java
@@ -12,7 +12,6 @@ public record ArticleWithLocationRequestDTO(
     @NotBlank(message = "장소명은 필수입니다.") String placeName,
     @NotBlank(message = "상세주소는 필수입니다.") String detailAddress,
     @NotBlank(message = "핀 카테고리는 필수입니다.") String pinCategory,
-    @NotNull(message = "지역 ID는 필수입니다.") Long regionId,
     @NotNull(message = "위도는 필수입니다.") Double latitude,
     @NotNull(message = "경도는 필수입니다.") Double longitude,
     @NotBlank(message = "제목은 필수입니다.") String title,


### PR DESCRIPTION
## #️⃣ 기능 설명
> 게시물 생성 (미등록 장소 포함) 시 request body의 `regionId `필드 제거

## 📸 스크린샷 (선택)
**게시물 생성:**
<img width="1330" height="713" alt="image" src="https://github.com/user-attachments/assets/675ab413-5a0e-4021-99fa-4e5650b09fcc" />
<img width="1339" height="746" alt="image" src="https://github.com/user-attachments/assets/e129d0aa-50ea-4299-8e34-44883f9c1e9a" />

**게시물 생성 (미등록 장소):**
<img width="1339" height="723" alt="image" src="https://github.com/user-attachments/assets/e0f0e49d-07a7-4972-8141-2c7967f469b0" />
<img width="1321" height="734" alt="image" src="https://github.com/user-attachments/assets/bd7c04be-ff61-44d8-85c7-1537465b3a59" />


## 💬 기타(공유사항 to 리뷰어)
- 테스트 코드를 추후에 수정할 예정이여서 swagger로 바로 테스트하였습니다.
- 기존 장소 생성 시에는 `regionId` 입력 없이 `Place`를 통해 검색
- 새 장소 생성 시에는 위도/경도로 지역 검색
  - 위경도 기반 지역 검색 로직 구현 필요 (현재는 임의 지역 반환)
  - **현재는 반환되는 `regionId`가 1로 고정되어 있습니다. 아래의 pr에서 이어 작업하였습니다.**
    - #240 
