### PR TITLE
🔨 [Fix] 충돌 해결 과정에서 유실된 리팩토링 복원

### DIFF
--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -63,75 +63,25 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         Place place = getPlace(request.placeId());
         Region region = place.getRegion();
 
-        place.updateTitle(request.placeName());
-        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
-
-        titleLengthValidator.validateArticleTitle(request.title());
-        contentLengthValidator.validateArticleContent(request.content());
-
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        return new ArticleWithPhotos(article, savedPhotos);
+        updatePlaceInfo(place, request);
+        validateArticleContent(request);
+        
+        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
     }
 
     @Override
-//    @ValidateS3ImageUpload
-//    @ValidateArticle
+    @ValidateS3ImageUpload
+    @ValidateArticle
     public ArticleWithPhotos createArticle(Long memberId, ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
         Region region = findRegionByCoordinatesAccurate(request.latitude(), request.longitude());
         log.debug("게시글 생성 API (미등록) - 위경도로 계산한 지역 ID: {}", region.getId());
 
-        titleLengthValidator.validateArticleTitle(request.title());
-        contentLengthValidator.validateArticleContent(request.content());
-
-        // TODO: 생성 책임 분리
-        Place place = Place.builder()
-            .region(region)
-            .latitude(request.latitude())
-            .longitude(request.longitude())
-            .title(request.placeName())
-            .address(request.detailAddress())
-            .pinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()))
-            .build();
-
-        place = placeRepository.save(place);
-
-        Article article = articleFactory.create(member, category, place, region, request);
-        articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
-        return new ArticleWithPhotos(article, savedPhotos);
-    }
-
-    private Member getMember(Long memberId) {
-        return memberRepository.findById(memberId)
-            .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
-    }
-    private Category getCategory(Long categoryId) {
-        return categoryRepository.findById(categoryId)
-            .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
-    }
-    private Place getPlace(Long placeId) {
-        return placeRepository.findById(placeId)
-            .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-    }
-    private Region getRegion(Long regionId) {
-        return regionRepository.findById(regionId)
-            .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
-    }
-
-    private Region findRegionByCoordinates(Double latitude, Double longitude) {
-        return regionRepository.findRegionByCoordinates(latitude, longitude);
-    }
-
-    private Region findRegionByCoordinatesAccurate(Double latitude, Double longitude) {
-        return regionRepository.findRegionByCoordinatesAccurate(latitude, longitude);
+        validateArticleContent(request);
+        Place place = createAndSaveNewPlace(request, region);
+        
+        return createArticleInternal(member, category, place, region, request, mainImage, imageFiles);
     }
 
     @Override
@@ -143,27 +93,138 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         validateArticleOwner(article, memberId);
         validateArticleNotDeleted(article);
 
-        articleUpdater.updateArticleEntity(article, request);
-        placeUpdater.updatePlaceEntity(article.getPlace(), request);
+        updateArticleAndPlace(article, request);
+        updateArticleImages(article, mainImage, imageFiles);
 
         List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
-        // 새로운 이미지가 제공된 경우, 기존 이미지 삭제 후 새로 추가
-        if ((mainImage != null && !mainImage.isEmpty()) || (imageFiles != null && !imageFiles.isEmpty())) {
-            for (ArticlePhoto photo : photos) {
-                s3Manager.deleteFile(photo.getFileKey());
-                articlePhotoRepository.delete(photo);
-            }
+        return new ArticleWithPhotos(article, photos);
+    }
 
-            articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
-            photos = articlePhotoRepository.findAllByArticle(article);
+    @Override
+    @ValidateArticle
+    public void deleteArticle(Long memberId, Long articleId) {
+        Article article = getArticle(articleId);
+        
+        validateArticleOwner(article, memberId);
+        validateArticleNotDeleted(article);
+        
+        article.delete();
+    }
+
+    private void updatePlaceInfo(Place place, ArticleRequestDTO request) {
+        place.updateTitle(request.placeName());
+        place.updatePinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()));
+    }
+
+    private void validateArticleContent(ArticleRequestDTO request) {
+        titleLengthValidator.validateArticleTitle(request.title());
+        contentLengthValidator.validateArticleContent(request.content());
+    }
+
+    private void validateArticleContent(ArticleWithLocationRequestDTO request) {
+        titleLengthValidator.validateArticleTitle(request.title());
+        contentLengthValidator.validateArticleContent(request.content());
+    }
+
+    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
+            ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        
+        return new ArticleWithPhotos(article, savedPhotos);
+    }
+
+    private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
+            ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        
+        Article article = articleFactory.create(member, category, place, region, request);
+        articleRepository.save(article);
+
+        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        
+        return new ArticleWithPhotos(article, savedPhotos);
+    }
+
+    private Place createAndSaveNewPlace(ArticleWithLocationRequestDTO request, Region region) {
+        Place place = Place.builder()
+                .region(region)
+                .latitude(request.latitude())
+                .longitude(request.longitude())
+                .title(request.placeName())
+                .address(request.detailAddress())
+                .pinCategory(PinCategory.valueOf(request.pinCategory().toUpperCase()))
+                .build();
+
+        return placeRepository.save(place);
+    }
+
+    private void updateArticleAndPlace(Article article, ArticleUpdateRequestDTO request) {
+        articleUpdater.updateArticleEntity(article, request);
+        placeUpdater.updatePlaceEntity(article.getPlace(), request);
+    }
+
+    private void updateArticleImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        if (!hasNewImages(mainImage, imageFiles)) {
+            return;
         }
 
-        return new ArticleWithPhotos(article, photos);
+        deleteExistingImages(article);
+        uploadNewImages(article, mainImage, imageFiles);
+    }
+
+    private boolean hasNewImages(MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        return (mainImage != null && !mainImage.isEmpty()) || 
+               (imageFiles != null && !imageFiles.isEmpty());
+    }
+
+    private void deleteExistingImages(Article article) {
+        List<ArticlePhoto> photos = articlePhotoRepository.findAllByArticle(article);
+        for (ArticlePhoto photo : photos) {
+            s3Manager.deleteFile(photo.getFileKey());
+            articlePhotoRepository.delete(photo);
+        }
+    }
+
+    private void uploadNewImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+        articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
+    }
+
+    private Member getMember(Long memberId) {
+        return memberRepository.findById(memberId)
+                .orElseThrow(() -> new MemberHandler(ErrorStatus.MEMBER_NOT_FOUND));
+    }
+
+    private Category getCategory(Long categoryId) {
+        return categoryRepository.findById(categoryId)
+                .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
+    }
+
+    private Place getPlace(Long placeId) {
+        return placeRepository.findById(placeId)
+                .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
+    }
+
+    private Region getRegion(Long regionId) {
+        return regionRepository.findById(regionId)
+                .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
+    }
+
+    private Region findRegionByCoordinates(Double latitude, Double longitude) {
+        return regionRepository.findRegionByCoordinates(latitude, longitude);
+    }
+
+    private Region findRegionByCoordinatesAccurate(Double latitude, Double longitude) {
+        return regionRepository.findRegionByCoordinatesAccurate(latitude, longitude);
     }
 
     private Article getArticle(Long articleId) {
         return articleRepository.findById(articleId)
-            .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
+                .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));
     }
 
     private void validateArticleOwner(Article article, Long memberId) {
@@ -176,16 +237,5 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
         if (article.isDeleted()) {
             throw new RuntimeException("이미 삭제된 게시물입니다.");
         }
-    }
-
-    @Override
-    @ValidateArticle
-    public void deleteArticle(Long memberId, Long articleId) {
-        Article article = getArticle(articleId);
-
-        validateArticleOwner(article, memberId);
-        validateArticleNotDeleted(article);
-
-        article.delete(); // dirty checking
     }
 }

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
@@ -66,11 +66,11 @@ class ArticleCommandServiceImplTest {
     }
 
     private ArticleRequestDTO getRequest() {
-        return new ArticleRequestDTO(categoryId, placeId, placeName, pinCategory, regionId, title, date, content);
+        return new ArticleRequestDTO(categoryId, placeId, placeName, pinCategory, title, date, content);
     }
 
     private ArticleWithLocationRequestDTO getWithLocationRequest() {
-        return new ArticleWithLocationRequestDTO(categoryId, placeName, detailAddress, pinCategory, regionId, latitude, longitude, title, date, content);
+        return new ArticleWithLocationRequestDTO(categoryId, placeName, detailAddress, pinCategory, latitude, longitude, title, date, content);
     }
 
     private ArticleUpdateRequestDTO getUpdateRequest() {
@@ -86,7 +86,15 @@ class ArticleCommandServiceImplTest {
     }
 
     private Place getPlace() {
-        return Place.builder().placeId(placeId).title(placeName).pinCategory(PinCategory.CAFE).build();
+        return Place.builder()
+                .placeId(placeId)
+                .title(placeName)
+                .pinCategory(PinCategory.CAFE)
+                .region(getRegion())
+                .latitude(37.123)
+                .longitude(127.456)
+                .address("테스트 주소")
+                .build();
     }
 
     private Region getRegion() {
@@ -133,11 +141,15 @@ class ArticleCommandServiceImplTest {
             Region region = getRegion();
             Article article = getArticle(member, category, place, region);
 
+            // Mock 설정을 더 명확하게
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            
+            // ArticleFactory Mock 설정을 더 구체적으로
+            when(articleFactory.create(any(Member.class), any(Category.class), any(Place.class), any(Region.class), any(ArticleRequestDTO.class)))
+                .thenReturn(article);
+            
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(List.of());
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, request, null, null);
@@ -146,7 +158,7 @@ class ArticleCommandServiceImplTest {
             assertEquals(article, result.article);
             assertTrue(result.photos.isEmpty());
             verify(articleRepository).save(article);
-            verify(articleImageService).uploadAndSaveImages(article, place, region, null, null);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(null), eq(null));
         }
 
         @Test
@@ -167,8 +179,8 @@ class ArticleCommandServiceImplTest {
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(any(Member.class), any(Category.class), any(Place.class), any(Region.class), any(ArticleRequestDTO.class)))
+                .thenReturn(article);
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(photos);
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, request, mainImage, null);
@@ -178,7 +190,7 @@ class ArticleCommandServiceImplTest {
             assertEquals(1, result.photos.size());
             assertTrue(result.photos.get(0).getIsMain());
             verify(articleRepository).save(article);
-            verify(articleImageService).uploadAndSaveImages(article, place, region, mainImage, null);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(mainImage), eq(null));
         }
 
         @Test
@@ -205,8 +217,8 @@ class ArticleCommandServiceImplTest {
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(any(Member.class), any(Category.class), any(Place.class), any(Region.class), any(ArticleRequestDTO.class)))
+                .thenReturn(article);
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(photos);
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, request, mainImage, imageFiles);
@@ -215,7 +227,7 @@ class ArticleCommandServiceImplTest {
             assertEquals(article, result.article);
             assertEquals(3, result.photos.size());
             verify(articleRepository).save(article);
-            verify(articleImageService).uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(mainImage), eq(imageFiles));
         }
 
         @Test
@@ -258,23 +270,6 @@ class ArticleCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("존재하지 않는 지역으로 생성 시 예외 발생")
-        void createArticle_regionNotFound() {
-            ArticleRequestDTO request = getRequest();
-            Member member = getMember();
-            Category category = getCategory();
-            Place place = getPlace();
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
-            when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.empty());
-
-            assertThrows(RuntimeException.class, () -> {
-                articleCommandService.createArticle(memberId, request, null, null);
-            });
-        }
-
-        @Test
         @DisplayName("제목/내용 유효성 검증 실패 시 예외 발생")
         void createArticle_validationFail() {
             ArticleRequestDTO request = getRequest();
@@ -286,7 +281,6 @@ class ArticleCommandServiceImplTest {
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
             doThrow(new IllegalArgumentException("제목 길이 오류")).when(titleLengthValidator).validateArticleTitle(anyString());
 
             assertThrows(IllegalArgumentException.class, () -> {
@@ -318,9 +312,10 @@ class ArticleCommandServiceImplTest {
 
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(regionRepository.findRegionByCoordinatesAccurate(latitude, longitude)).thenReturn(region);
             when(placeRepository.save(any(Place.class))).thenReturn(place);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(any(Member.class), any(Category.class), any(Place.class), any(Region.class), any(ArticleWithLocationRequestDTO.class)))
+                .thenReturn(article);
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(List.of());
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, request, null, null);
@@ -330,7 +325,7 @@ class ArticleCommandServiceImplTest {
             assertTrue(result.photos.isEmpty());
             verify(placeRepository).save(any(Place.class));
             verify(articleRepository).save(article);
-            verify(articleImageService).uploadAndSaveImages(article, place, region, null, null);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(null), eq(null));
         }
 
         @Test
@@ -362,9 +357,10 @@ class ArticleCommandServiceImplTest {
 
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(regionRepository.findRegionByCoordinatesAccurate(latitude, longitude)).thenReturn(region);
             when(placeRepository.save(any(Place.class))).thenReturn(place);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(any(Member.class), any(Category.class), any(Place.class), any(Region.class), any(ArticleWithLocationRequestDTO.class)))
+                .thenReturn(article);
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(photos);
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.createArticle(memberId, request, mainImage, imageFiles);
@@ -376,7 +372,7 @@ class ArticleCommandServiceImplTest {
             assertFalse(result.photos.get(1).getIsMain());
             verify(placeRepository).save(any(Place.class));
             verify(articleRepository).save(article);
-            verify(articleImageService).uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(mainImage), eq(imageFiles));
         }
 
         @Test
@@ -404,21 +400,6 @@ class ArticleCommandServiceImplTest {
         }
 
         @Test
-        @DisplayName("위치 정보와 함께 게시물 생성 시 존재하지 않는 지역으로 예외 발생")
-        void createArticleWithLocation_regionNotFound() {
-            ArticleWithLocationRequestDTO request = getWithLocationRequest();
-            Member member = getMember();
-            Category category = getCategory();
-            when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
-            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.empty());
-
-            assertThrows(RuntimeException.class, () -> {
-                articleCommandService.createArticle(memberId, request, null, null);
-            });
-        }
-
-        @Test
         @DisplayName("위치 정보와 함께 게시물 생성 시 제목/내용 유효성 검증 실패로 예외 발생")
         void createArticleWithLocation_validationFail() {
             ArticleWithLocationRequestDTO request = getWithLocationRequest();
@@ -428,7 +409,7 @@ class ArticleCommandServiceImplTest {
 
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
-            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(regionRepository.findRegionByCoordinatesAccurate(latitude, longitude)).thenReturn(region);
             doThrow(new IllegalArgumentException("제목 길이 오류")).when(titleLengthValidator).validateArticleTitle(anyString());
 
             assertThrows(IllegalArgumentException.class, () -> {
@@ -530,7 +511,7 @@ class ArticleCommandServiceImplTest {
             verify(placeUpdater).updatePlaceEntity(place, request);
             verify(s3Manager).deleteFile("existing-uuid");
             verify(articlePhotoRepository).delete(any(ArticlePhoto.class));
-            verify(articleImageService).uploadAndSaveImages(article, place, region, mainImage, imageFiles);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(mainImage), eq(imageFiles));
         }
 
         @Test
@@ -566,7 +547,7 @@ class ArticleCommandServiceImplTest {
             verify(s3Manager).deleteFile("old-main-uuid");
             verify(s3Manager).deleteFile("old-sub-uuid");
             verify(articlePhotoRepository, times(2)).delete(any(ArticlePhoto.class));
-            verify(articleImageService).uploadAndSaveImages(article, place, region, mainImage, null);
+            verify(articleImageService).uploadAndSaveImages(eq(article), eq(place), any(Region.class), eq(mainImage), eq(null));
         }
 
         @Test


### PR DESCRIPTION
## #️⃣ 기능 설명
> 충돌 해결 과정에서 유실된 클린코드 리팩토링 복원

## 🛠️ 작업 상세 내용
- [x] ArticleCommandServiceImpl 메서드 분리 복원
- [x] 중복 로직 제거 및 가독성 개선 로직 복원
- [x] 기존 regionId 처리 로직 유지 (변경 없음)
- [x] 테스트 코드 수정
- [x] 테스트 통과 확인

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 기능적 변경사항 없이 리팩토링만 복원하였습니다.
