### PR TITLE
🔨 [Fix] S3 이미지 업로드 데이터 무결성 문제 해결

### DIFF
--- a/src/main/java/DNBN/spring/domain/ArticlePhoto.java
+++ b/src/main/java/DNBN/spring/domain/ArticlePhoto.java
@@ -9,6 +9,7 @@ import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @Getter
+@Setter
 @DynamicInsert
 @DynamicUpdate
 @Builder

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -53,10 +53,11 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     private final ArticleUpdater articleUpdater;
     private final PlaceUpdater placeUpdater;
     private final ArticleFactory articleFactory;
+    private final ArticleImageUploadService articleImageUploadService;
 
     @Override
-//    @ValidateS3ImageUpload
-//    @ValidateArticle
+    @ValidateS3ImageUpload
+    @ValidateArticle
     public ArticleWithPhotos createArticle(Long memberId, ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         Member member = getMember(memberId);
         Category category = getCategory(request.categoryId());
@@ -129,23 +130,25 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
             ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
         
+        List<ArticlePhoto> photos = articleImageUploadService.uploadImages(place, region, mainImage, imageFiles);
+        
         Article article = articleFactory.create(member, category, place, region, request);
         articleRepository.save(article);
-
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        
+        List<ArticlePhoto> savedPhotos = articleImageUploadService.saveImagesWithArticle(photos, article);
         
         return new ArticleWithPhotos(article, savedPhotos);
     }
 
     private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
             ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
+
+        List<ArticlePhoto> photos = articleImageUploadService.uploadImages(place, region, mainImage, imageFiles);
         
         Article article = articleFactory.create(member, category, place, region, request);
         articleRepository.save(article);
 
-        articleImageService.uploadAndSaveImages(article, place, region, mainImage, imageFiles);
-        List<ArticlePhoto> savedPhotos = articlePhotoRepository.findAllByArticle(article);
+        List<ArticlePhoto> savedPhotos = articleImageUploadService.saveImagesWithArticle(photos, article);
         
         return new ArticleWithPhotos(article, savedPhotos);
     }
@@ -191,7 +194,9 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     }
 
     private void uploadNewImages(Article article, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        articleImageService.uploadAndSaveImages(article, article.getPlace(), article.getRegion(), mainImage, imageFiles);
+        // 이미지 업로드 먼저 진행
+        List<ArticlePhoto> photos = articleImageUploadService.uploadImages(article.getPlace(), article.getRegion(), mainImage, imageFiles);
+        articleImageUploadService.saveImagesWithArticle(photos, article);
     }
 
     private Member getMember(Long memberId) {


### PR DESCRIPTION
## #️⃣ 기능 설명
> 추가하려는 기능에 대해 간결하게 설명해주세요

## 🛠️ 작업 상세 내용
- [x] S3 업로드 실패 시 예외 처리 개선 (`AmazonS3Manager`)
- [x] 메인 이미지 검증 추가 (`ArticleImageService`)
- [x] 트랜잭션 순서 개선으로 데이터 일관성 보장 (이미지 업로드 후 게시글 생성 -> 예외로 이미지 롤백 시 게시글 또한 미생성 의도)
- [x] `setArticle` 메서드 사용을 위해 `ArticlePhoto`에 `@Setter` 추가

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 급하게 구현하느라 엔티티에 `@Setter` 어노테이션을 사용하였습니다..
- 버그는 해결되었지만 정확한 문제 원인을 모르는 상황입니다. 프론트에서는 이전 검증 pr 배포 시점에서 배열이 채워졌다고 하는데, 해당 pr에 로직 변화가 없는 상황입니다.
  - #246 
  - #247 
- **시간상 변경하지는 못했지만, 처음부터 `Presigned URL`로 구현하는 것이 더 좋을 것 같습니다.**