### PR TITLE
♻️ [Refactor] AOP와 Validation 일관성 확보

### DIFF
--- a/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
+++ b/src/main/java/DNBN/spring/aop/CommentValidationAspect.java
@@ -25,47 +25,51 @@ public class CommentValidationAspect {
     @Before("@annotation(DNBN.spring.aop.annotation.ValidateComment)")
     public void validateComment(JoinPoint joinPoint) {
         Object[] args = joinPoint.getArgs();
-        // 파라미터 타입/순서 검증
-        if (args.length < 3 || !(args[0] instanceof Long) || (args[1] != null && !(args[1] instanceof Long)) || !(args[2] instanceof Long)) {
-            throw new IllegalArgumentException("❌ CommentValidationAspect: memberId, commentId, articleId 파라미터 타입/순서 오류");
-        }
-        Long memberId = extractLongArg(args, 0, "memberId");
-        Long commentId = extractLongArg(args, 1, "commentId");
-        Long articleId = extractLongArg(args, 2, "articleId");
-        Comment comment = null;
-        // commentId가 null이면 예외 발생
-        if (args[1] == null) {
-            throw new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND);
-        }
-        // createComment의 경우 parentCommentId만 존재
-        if (commentId != null) {
-            comment = commentRepository.findById(commentId)
-                .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
-            validateCommentOwnership(comment, memberId, articleId);
+        String methodName = joinPoint.getSignature().getName();
+        
+        if ("createComment".equals(methodName)) {
+            validateCreateComment(args);
+        } else if ("deleteComment".equals(methodName)) {
+            validateDeleteComment(args);
         } else {
-            // createComment: parentCommentId 검증
-            CommentRequestDTO requestDto = (CommentRequestDTO) extractDto(args);
-            if (requestDto != null && requestDto.parentCommentId() != null) {
-                Comment parentComment = commentRepository.findById(requestDto.parentCommentId())
-                    .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
-                if (!parentComment.getArticle().getArticleId().equals(articleId)) {
-                    throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
-                }
+            throw new IllegalArgumentException("❌ CommentValidationAspect: 지원하지 않는 메서드: " + methodName);
+        }
+    }
+
+    private void validateCreateComment(Object[] args) {
+        if (args.length < 3 || !(args[0] instanceof Long) || !(args[1] instanceof Long) || !(args[2] instanceof CommentRequestDTO)) {
+            throw new IllegalArgumentException("❌ CommentValidationAspect: createComment 파라미터 타입/순서 오류");
+        }
+        
+        Long memberId = (Long) args[0];
+        Long articleId = (Long) args[1];
+        CommentRequestDTO requestDto = (CommentRequestDTO) args[2];
+        
+        // parentComment 검증
+        if (requestDto.parentCommentId() != null) {
+            Comment parentComment = commentRepository.findById(requestDto.parentCommentId())
+                .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+            
+            // parentComment가 해당 게시글에 속하는지 검증
+            if (!parentComment.getArticle().getArticleId().equals(articleId)) {
+                throw new CommentHandler(ErrorStatus.COMMENT_FORBIDDEN);
             }
         }
     }
 
-    private Long extractLongArg(Object[] args, int idx, String name) {
-        if (args.length <= idx) {
-            throw new IllegalArgumentException("❌ CommentValidationAspect: " + name + " 인자 오류");
+    private void validateDeleteComment(Object[] args) {
+        if (args.length < 3 || !(args[0] instanceof Long) || !(args[1] instanceof Long) || !(args[2] instanceof Long)) {
+            throw new IllegalArgumentException("❌ CommentValidationAspect: deleteComment 파라미터 타입/순서 오류");
         }
-        if (args[idx] == null) {
-            return null;
-        }
-        if (!(args[idx] instanceof Long value)) {
-            throw new IllegalArgumentException("❌ CommentValidationAspect: " + name + " 인자 오류");
-        }
-        return value;
+        
+        Long memberId = (Long) args[0];
+        Long commentId = (Long) args[1];
+        Long articleId = (Long) args[2];
+        
+        Comment comment = commentRepository.findById(commentId)
+            .orElseThrow(() -> new CommentHandler(ErrorStatus.COMMENT_NOT_FOUND));
+        
+        validateCommentOwnership(comment, memberId, articleId);
     }
 
     private void validateCommentOwnership(Comment comment, Long memberId, Long articleId) {
@@ -77,28 +81,6 @@ public class CommentValidationAspect {
         }
         if (comment.getDeletedAt() != null) {
             throw new CommentHandler(ErrorStatus.COMMENT_ALREADY_DELETED);
-        }
-    }
-
-    private Object extractDto(Object[] args) {
-        for (Object arg : args) {
-            if (arg instanceof CommentRequestDTO || arg instanceof CommentUpdateRequestDTO) {
-                return arg;
-            }
-        }
-        return null;
-    }
-
-    private Pair<String, String> extractContentFromDto(Object dto) {
-        if (dto == null) {
-            throw new CommentHandler(ErrorStatus.COMMENT_CONTENT_NULL_ERROR);
-        }
-        try {
-            var contentMethod = dto.getClass().getMethod("content");
-            String content = (String) contentMethod.invoke(dto);
-            return Pair.of(content, null);
-        } catch (Exception e) {
-            throw new IllegalArgumentException("❌ CommentValidationAspect: DTO에서 content 추출 실패", e);
         }
     }
 }

--- a/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/CommentService/CommentCommandServiceImpl.java
@@ -41,6 +41,7 @@ public class CommentCommandServiceImpl implements CommentCommandService {
     }
 
     @Override
+    @ValidateComment
     public CommentResponseDTO createComment(Long memberId, Long articleId, CommentRequestDTO request) {
         Article article = articleRepository.findById(articleId)
                 .orElseThrow(() -> new ArticleHandler(ErrorStatus.ARTICLE_NOT_FOUND));

--- a/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/MemberService/MemberCommandServiceImpl.java
@@ -259,18 +259,6 @@ public class MemberCommandServiceImpl implements MemberCommandService {
             throw new MemberHandler(ErrorStatus._BAD_REQUEST);
         }
 
-        // 파일 형식 검사
-        String contentType = profileImage.getContentType();
-        if (contentType == null || !contentType.startsWith("image/")) {
-            throw new MemberHandler(ErrorStatus.INVALID_IMAGE_TYPE);
-        }
-
-        // 파일 용량 제한 (10MB)
-        long maxFileSize = 10 * 1024 * 1024;
-        if (profileImage.getSize() > maxFileSize) {
-            throw new MemberHandler(ErrorStatus.IMAGE_FILE_TOO_LARGE);
-        }
-
         // UUID 생성 후 저장
         String uuidStr = UUID.randomUUID().toString();
         Uuid uuid = uuidRepository.save(Uuid.builder().uuid(uuidStr).build());


### PR DESCRIPTION
## #️⃣ 기능 설명
> AOP와 Validation 공통 로직 분리의 일관성 확보 및 중복 검증 로직 제거

## 🛠️ 작업 상세 내용
- [x] `createComment()` 메서드에 `@ValidateComment` 어노테이션 추가
- [x] AOP와 수동 검증이 중복되는 부분 정리 (`Article`, `Member` 프로필 이미지 업로드)
- [x] `CommentValidationAspect`에서 `createComment` 케이스도 처리하도록 로직 개선
- [x] 테스트 코드 통과 확인

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
