### PR TITLE
♻️ [Refactor] Article 도메인 구조 리팩토링

### DIFF
--- a/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/DNBN/spring/apiPayload/code/status/ErrorStatus.java
@@ -34,6 +34,10 @@ public enum ErrorStatus implements BaseErrorCode {
     ARTICLE_ALREADY_DELETED(HttpStatus.CONFLICT, "ARTICLE4005", "이미 삭제된 게시글입니다."),
     ARTICLE_TITLE_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4006", "제목이 비어 있습니다."),
     ARTICLE_CONTENT_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4007", "내용이 비어 있습니다."),
+    ARTICLE_DATE_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4008", "날짜가 비어 있습니다."),
+    ARTICLE_CATEGORY_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4009", "카테고리가 비어 있습니다."),
+    ARTICLE_PLACE_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4010", "장소가 비어 있습니다."),
+    ARTICLE_REGION_NULL_ERROR(HttpStatus.BAD_REQUEST, "ARTICLE4011", "지역이 비어 있습니다."),
 
     // articlePhoto & S3
     ARTICLE_PHOTO_MAIN_IMAGE_REQUIRED(HttpStatus.BAD_REQUEST, "ARTICLEPHOTO4002", "대표 이미지는 필수입니다."),

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -7,6 +7,8 @@ import java.time.LocalDateTime;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.DynamicUpdate;
+import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
+import DNBN.spring.apiPayload.code.status.ErrorStatus;
 
 @Entity
 @Getter
@@ -101,27 +103,45 @@ public class Article extends BaseEntity {
     return !isDeleted();
   }
 
-  public void setTitle(String title) {
+  public void updateTitle(String title) {
+    if (title == null || title.trim().isEmpty()) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_TITLE_NULL_ERROR);
+    }
     this.title = title;
   }
 
-  public void setContent(String content) {
+  public void updateContent(String content) {
+    if (content == null || content.trim().isEmpty()) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_CONTENT_NULL_ERROR);
+    }
     this.content = content;
   }
 
-  public void setDate(LocalDate date) {
+  public void updateDate(LocalDate date) {
+    if (date == null) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_DATE_NULL_ERROR);
+    }
     this.date = date;
   }
 
-  public void setCategory(Category category) {
+  public void updateCategory(Category category) {
+    if (category == null) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_CATEGORY_NULL_ERROR);
+    }
     this.category = category;
   }
 
-  public void setPlace(Place place) {
+  public void updatePlace(Place place) {
+    if (place == null) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_PLACE_NULL_ERROR);
+    }
     this.place = place;
   }
 
-  public void setRegion(Region region) {
+  public void updateRegion(Region region) {
+    if (region == null) {
+      throw new ArticleHandler(ErrorStatus.ARTICLE_REGION_NULL_ERROR);
+    }
     this.region = region;
   }
 

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -16,7 +16,6 @@ import DNBN.spring.apiPayload.code.status.ErrorStatus;
 @DynamicUpdate
 @Builder
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@AllArgsConstructor
 public class Article extends BaseEntity {
 
   @Id
@@ -148,4 +147,31 @@ public class Article extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "challengeId")
   private Challenge challenge;
+
+    @Builder
+    public Article(Long articleId, Member member, Category category, Place place, Region region, String title, String content, Long likesCount, Long spamCount, Long commentCount, LocalDateTime deletedAt, String hashtag, LocalDate date, Challenge challenge) {
+        if (title == null || title.trim().isEmpty()) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_TITLE_NULL_ERROR);
+        }
+        if (content == null || content.trim().isEmpty()) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_CONTENT_NULL_ERROR);
+        }
+        if (date == null) {
+            throw new ArticleHandler(ErrorStatus.ARTICLE_DATE_NULL_ERROR);
+        }
+        this.articleId = articleId;
+        this.member = member;
+        this.category = category;
+        this.place = place;
+        this.region = region;
+        this.title = title;
+        this.content = content;
+        this.likesCount = likesCount == null ? 0L : likesCount;
+        this.spamCount = spamCount == null ? 0L : spamCount;
+        this.commentCount = commentCount;
+        this.deletedAt = deletedAt;
+        this.hashtag = hashtag;
+        this.date = date;
+        this.challenge = challenge;
+    }
 }

--- a/src/main/java/DNBN/spring/domain/Article.java
+++ b/src/main/java/DNBN/spring/domain/Article.java
@@ -128,33 +128,4 @@ public class Article extends BaseEntity {
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "challengeId")
   private Challenge challenge;
-
-  public static Article createFromRequest(Member member, Category category, Place place, Region region, DNBN.spring.web.dto.request.ArticleRequestDTO request) {
-        return Article.builder()
-                .member(member)
-                .category(category)
-                .place(place)
-                .region(region)
-                .title(request.title())
-                .date(request.date())
-                .content(request.content())
-                .likesCount(0L)
-                .spamCount(0L)
-                .commentCount(0L)
-                .build();
-    }
-    public static Article createFromRequest(Member member, Category category, Place place, Region region, DNBN.spring.web.dto.request.ArticleWithLocationRequestDTO request) {
-        return Article.builder()
-                .member(member)
-                .category(category)
-                .place(place)
-                .region(region)
-                .title(request.title())
-                .date(request.date())
-                .content(request.content())
-                .likesCount(0L)
-                .spamCount(0L)
-                .commentCount(0L)
-                .build();
-    }
 }

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -123,14 +123,20 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
 
     private ArticleWithPhotos createArticleInternal(Member member, Category category, Place place, Region region, 
             ArticleRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
-        
+
         List<ArticlePhoto> photos = articleImageUploadService.uploadImages(place, region, mainImage, imageFiles);
-        
-        Article article = articleFactory.create(member, category, place, region, request);
+        Article article = articleFactory.create(
+            member,
+            category,
+            place,
+            region,
+            request.title(),
+            request.date(),
+            request.content()
+        );
         articleRepository.save(article);
-        
         List<ArticlePhoto> savedPhotos = articleImageUploadService.saveImagesWithArticle(photos, article);
-        
+
         return new ArticleWithPhotos(article, savedPhotos);
     }
 
@@ -138,12 +144,18 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
             ArticleWithLocationRequestDTO request, MultipartFile mainImage, List<MultipartFile> imageFiles) {
 
         List<ArticlePhoto> photos = articleImageUploadService.uploadImages(place, region, mainImage, imageFiles);
-        
-        Article article = articleFactory.create(member, category, place, region, request);
+        Article article = articleFactory.create(
+            member,
+            category,
+            place,
+            region,
+            request.title(),
+            request.date(),
+            request.content()
+        );
         articleRepository.save(article);
-
         List<ArticlePhoto> savedPhotos = articleImageUploadService.saveImagesWithArticle(photos, article);
-        
+
         return new ArticleWithPhotos(article, savedPhotos);
     }
 

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImpl.java
@@ -2,12 +2,6 @@ package DNBN.spring.service.ArticleService;
 
 import DNBN.spring.aop.annotation.ValidateArticle;
 import DNBN.spring.aop.annotation.ValidateS3ImageUpload;
-import DNBN.spring.apiPayload.code.status.ErrorStatus;
-import DNBN.spring.apiPayload.exception.handler.ArticleHandler;
-import DNBN.spring.apiPayload.exception.handler.CategoryHandler;
-import DNBN.spring.apiPayload.exception.handler.MemberHandler;
-import DNBN.spring.apiPayload.exception.handler.PlaceHandler;
-import DNBN.spring.apiPayload.exception.handler.RegionHandler;
 import DNBN.spring.aws.s3.AmazonS3Manager;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.ArticlePhoto;
@@ -173,7 +167,27 @@ public class ArticleCommandServiceImpl implements ArticleCommandService {
     }
 
     private void updateArticleAndPlace(Article article, ArticleUpdateRequestDTO request) {
-        articleUpdater.updateArticleEntity(article, request);
+        if (request.title() != null) {
+            articleUpdater.updateTitle(article, request.title());
+        }
+        if (request.content() != null) {
+            articleUpdater.updateContent(article, request.content());
+        }
+        if (request.date() != null) {
+            articleUpdater.updateDate(article, request.date());
+        }
+        if (request.categoryId() != null) {
+            Category category = getCategory(request.categoryId());
+            articleUpdater.updateCategory(article, category);
+        }
+        if (request.regionId() != null) {
+            Region region = getRegion(request.regionId());
+            articleUpdater.updateRegion(article, region);
+        }
+        if (request.placeId() != null) {
+            Place place = getPlace(request.placeId());
+            articleUpdater.updatePlace(article, place);
+        }
         placeUpdater.updatePlaceEntity(article.getPlace(), request);
     }
 

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleFactory.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleFactory.java
@@ -5,38 +5,22 @@ import DNBN.spring.domain.Category;
 import DNBN.spring.domain.Member;
 import DNBN.spring.domain.Place;
 import DNBN.spring.domain.Region;
-import DNBN.spring.web.dto.request.ArticleRequestDTO;
-import DNBN.spring.web.dto.request.ArticleWithLocationRequestDTO;
+import java.time.LocalDate;
 import org.springframework.stereotype.Component;
 
 @Component
 public class ArticleFactory {
-    public Article create(Member member, Category category, Place place, Region region, ArticleRequestDTO request) {
+    public Article create(Member member, Category category, Place place, Region region, String title, LocalDate date, String content) {
         return Article.builder()
                 .member(member)
                 .category(category)
                 .place(place)
                 .region(region)
-                .title(request.title())
-                .date(request.date())
-                .content(request.content())
-                .likesCount(0L)
-                .spamCount(0L)
-                .build();
-    }
-
-    public Article create(Member member, Category category, Place place, Region region, ArticleWithLocationRequestDTO request) {
-        return Article.builder()
-                .member(member)
-                .category(category)
-                .place(place)
-                .region(region)
-                .title(request.title())
-                .date(request.date())
-                .content(request.content())
+                .title(title)
+                .date(date)
+                .content(content)
                 .likesCount(0L)
                 .spamCount(0L)
                 .build();
     }
 }
-

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleFactory.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleFactory.java
@@ -12,10 +12,31 @@ import org.springframework.stereotype.Component;
 @Component
 public class ArticleFactory {
     public Article create(Member member, Category category, Place place, Region region, ArticleRequestDTO request) {
-        return Article.createFromRequest(member, category, place, region, request);
+        return Article.builder()
+                .member(member)
+                .category(category)
+                .place(place)
+                .region(region)
+                .title(request.title())
+                .date(request.date())
+                .content(request.content())
+                .likesCount(0L)
+                .spamCount(0L)
+                .build();
     }
 
     public Article create(Member member, Category category, Place place, Region region, ArticleWithLocationRequestDTO request) {
-        return Article.createFromRequest(member, category, place, region, request);
+        return Article.builder()
+                .member(member)
+                .category(category)
+                .place(place)
+                .region(region)
+                .title(request.title())
+                .date(request.date())
+                .content(request.content())
+                .likesCount(0L)
+                .spamCount(0L)
+                .build();
     }
 }
+

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleUpdater.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleUpdater.java
@@ -29,30 +29,29 @@ public class ArticleUpdater {
     public void updateArticleEntity(Article article, ArticleUpdateRequestDTO request) {
         if (request.title() != null) {
             titleLengthValidator.validateArticleTitle(request.title());
-            article.setTitle(request.title());
+            article.updateTitle(request.title());
         }
         if (request.content() != null) {
             contentLengthValidator.validateArticleContent(request.content());
-            article.setContent(request.content());
+            article.updateContent(request.content());
         }
         if (request.date() != null) {
-            article.setDate(request.date());
+            article.updateDate(request.date());
         }
         if (request.categoryId() != null) {
             Category category = categoryRepository.findById(request.categoryId())
                     .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
-            article.setCategory(category);
+            article.updateCategory(category);
         }
         if (request.regionId() != null) {
             Region region = regionRepository.findById(request.regionId())
                     .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
-            article.setRegion(region);
+            article.updateRegion(region);
         }
         if (request.placeId() != null) {
             Place place = placeRepository.findById(request.placeId())
                     .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-            article.setPlace(place);
+            article.updatePlace(place);
         }
     }
 }
-

--- a/src/main/java/DNBN/spring/service/ArticleService/ArticleUpdater.java
+++ b/src/main/java/DNBN/spring/service/ArticleService/ArticleUpdater.java
@@ -1,19 +1,12 @@
 package DNBN.spring.service.ArticleService;
 
-import DNBN.spring.apiPayload.code.status.ErrorStatus;
-import DNBN.spring.apiPayload.exception.handler.CategoryHandler;
-import DNBN.spring.apiPayload.exception.handler.PlaceHandler;
-import DNBN.spring.apiPayload.exception.handler.RegionHandler;
 import DNBN.spring.domain.Article;
 import DNBN.spring.domain.Category;
 import DNBN.spring.domain.Place;
 import DNBN.spring.domain.Region;
-import DNBN.spring.repository.CategoryRepository.CategoryRepository;
-import DNBN.spring.repository.PlaceRepository.PlaceRepository;
-import DNBN.spring.repository.RegionRepository.RegionRepository;
 import DNBN.spring.validation.validator.ContentLengthValidator;
 import DNBN.spring.validation.validator.TitleLengthValidator;
-import DNBN.spring.web.dto.request.ArticleUpdateRequestDTO;
+import java.time.LocalDate;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -22,36 +15,25 @@ import org.springframework.stereotype.Component;
 public class ArticleUpdater {
     private final TitleLengthValidator titleLengthValidator;
     private final ContentLengthValidator contentLengthValidator;
-    private final CategoryRepository categoryRepository;
-    private final PlaceRepository placeRepository;
-    private final RegionRepository regionRepository;
 
-    public void updateArticleEntity(Article article, ArticleUpdateRequestDTO request) {
-        if (request.title() != null) {
-            titleLengthValidator.validateArticleTitle(request.title());
-            article.updateTitle(request.title());
-        }
-        if (request.content() != null) {
-            contentLengthValidator.validateArticleContent(request.content());
-            article.updateContent(request.content());
-        }
-        if (request.date() != null) {
-            article.updateDate(request.date());
-        }
-        if (request.categoryId() != null) {
-            Category category = categoryRepository.findById(request.categoryId())
-                    .orElseThrow(() -> new CategoryHandler(ErrorStatus.CATEGORY_NOT_FOUND));
-            article.updateCategory(category);
-        }
-        if (request.regionId() != null) {
-            Region region = regionRepository.findById(request.regionId())
-                    .orElseThrow(() -> new RegionHandler(ErrorStatus.REGION_NOT_FOUND));
-            article.updateRegion(region);
-        }
-        if (request.placeId() != null) {
-            Place place = placeRepository.findById(request.placeId())
-                    .orElseThrow(() -> new PlaceHandler(ErrorStatus.PLACE_NOT_FOUND));
-            article.updatePlace(place);
-        }
+    public void updateTitle(Article article, String title) {
+        titleLengthValidator.validateArticleTitle(title);
+        article.updateTitle(title);
+    }
+    public void updateContent(Article article, String content) {
+        contentLengthValidator.validateArticleContent(content);
+        article.updateContent(content);
+    }
+    public void updateDate(Article article, LocalDate date) {
+        article.updateDate(date);
+    }
+    public void updateCategory(Article article, Category category) {
+        article.updateCategory(category);
+    }
+    public void updateRegion(Article article, Region region) {
+        article.updateRegion(region);
+    }
+    public void updatePlace(Article article, Place place) {
+        article.updatePlace(place);
     }
 }

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
@@ -476,13 +476,21 @@ class ArticleCommandServiceImplTest {
 
             when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(List.of());
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.updateArticle(memberId, articleId, request, null, null);
 
             assertNotNull(result);
             assertEquals(article, result.article);
             assertTrue(result.photos.isEmpty());
-            verify(articleUpdater).updateArticleEntity(article, request);
+            verify(articleUpdater).updateTitle(article, request.title());
+            verify(articleUpdater).updateContent(article, request.content());
+            verify(articleUpdater).updateDate(article, request.date());
+            verify(articleUpdater).updateCategory(article, category);
+            verify(articleUpdater).updateRegion(article, region);
+            verify(articleUpdater).updatePlace(article, place);
             verify(placeUpdater).updatePlaceEntity(place, request);
             verify(articleImageUploadService, never()).uploadImages(any(), any(), any(), any());
         }
@@ -504,13 +512,21 @@ class ArticleCommandServiceImplTest {
 
             when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(existingPhotos);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.updateArticle(memberId, articleId, request, null, null);
 
             assertNotNull(result);
             assertEquals(article, result.article);
             assertEquals(1, result.photos.size());
-            verify(articleUpdater).updateArticleEntity(article, request);
+            verify(articleUpdater).updateTitle(article, request.title());
+            verify(articleUpdater).updateContent(article, request.content());
+            verify(articleUpdater).updateDate(article, request.date());
+            verify(articleUpdater).updateCategory(article, category);
+            verify(articleUpdater).updateRegion(article, region);
+            verify(articleUpdater).updatePlace(article, place);
             verify(placeUpdater).updatePlaceEntity(place, request);
             verify(articleImageUploadService, never()).uploadImages(any(), any(), any(), any());
         }
@@ -542,13 +558,21 @@ class ArticleCommandServiceImplTest {
             when(mainImage.isEmpty()).thenReturn(false);
             when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(existingPhotos).thenReturn(newPhotos);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.updateArticle(memberId, articleId, request, mainImage, imageFiles);
 
             assertNotNull(result);
             assertEquals(article, result.article);
             assertEquals(2, result.photos.size());
-            verify(articleUpdater).updateArticleEntity(article, request);
+            verify(articleUpdater).updateTitle(article, request.title());
+            verify(articleUpdater).updateContent(article, request.content());
+            verify(articleUpdater).updateDate(article, request.date());
+            verify(articleUpdater).updateCategory(article, category);
+            verify(articleUpdater).updateRegion(article, region);
+            verify(articleUpdater).updatePlace(article, place);
             verify(placeUpdater).updatePlaceEntity(place, request);
             verify(s3Manager).deleteFile("existing-uuid");
             verify(articlePhotoRepository).delete(any(ArticlePhoto.class));
@@ -580,6 +604,9 @@ class ArticleCommandServiceImplTest {
             when(mainImage.isEmpty()).thenReturn(false);
             when(articleRepository.findById(articleId)).thenReturn(Optional.of(article));
             when(articlePhotoRepository.findAllByArticle(article)).thenReturn(existingPhotos).thenReturn(newPhotos);
+            when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
+            when(regionRepository.findById(regionId)).thenReturn(Optional.of(region));
+            when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
 
             ArticleCommandService.ArticleWithPhotos result = articleCommandService.updateArticle(memberId, articleId, request, mainImage, null);
 

--- a/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
+++ b/src/test/java/DNBN/spring/service/ArticleService/ArticleCommandServiceImplTest.java
@@ -144,17 +144,14 @@ class ArticleCommandServiceImplTest {
 
             List<ArticlePhoto> photos = List.of();
 
-            // Mock 설정을 실제 메서드 호출 순서대로 정렬
             when(memberRepository.findById(memberId)).thenReturn(Optional.of(member));
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
             when(articleImageUploadService.uploadImages(place, region, null, null)).thenReturn(photos);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(member, category, place, region, request.title(), request.date(), request.content())).thenReturn(article);
             when(articleRepository.save(article)).thenReturn(article);
             when(articleImageUploadService.saveImagesWithArticle(photos, article)).thenReturn(photos);
 
-            // AOP 어노테이션을 우회하여 실제 구현체 메서드 직접 호출
-            // Reflection을 사용하여 private 메서드에 접근
             try {
                 java.lang.reflect.Method createArticleInternal = ArticleCommandServiceImpl.class
                     .getDeclaredMethod("createArticleInternal", Member.class, Category.class, Place.class, Region.class, 
@@ -163,11 +160,6 @@ class ArticleCommandServiceImplTest {
                 
                 ArticleCommandService.ArticleWithPhotos result = (ArticleCommandService.ArticleWithPhotos) 
                     createArticleInternal.invoke(articleCommandService, member, category, place, region, request, null, null);
-
-                // 디버깅을 위한 로그 추가
-                System.out.println("Result: " + result);
-                System.out.println("Result.article: " + result.article);
-                System.out.println("Expected article: " + article);
 
                 assertNotNull(result);
                 assertEquals(article, result.article);
@@ -199,7 +191,7 @@ class ArticleCommandServiceImplTest {
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
             when(articleImageUploadService.uploadImages(place, region, mainImage, null)).thenReturn(photos);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(member, category, place, region, request.title(), request.date(), request.content())).thenReturn(article);
             when(articleRepository.save(article)).thenReturn(article);
             when(articleImageUploadService.saveImagesWithArticle(photos, article)).thenReturn(photos);
 
@@ -249,7 +241,7 @@ class ArticleCommandServiceImplTest {
             when(categoryRepository.findById(categoryId)).thenReturn(Optional.of(category));
             when(placeRepository.findById(placeId)).thenReturn(Optional.of(place));
             when(articleImageUploadService.uploadImages(place, region, mainImage, imageFiles)).thenReturn(photos);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(member, category, place, region, request.title(), request.date(), request.content())).thenReturn(article);
             when(articleRepository.save(article)).thenReturn(article);
             when(articleImageUploadService.saveImagesWithArticle(photos, article)).thenReturn(photos);
 
@@ -360,7 +352,7 @@ class ArticleCommandServiceImplTest {
             when(regionRepository.findRegionByCoordinatesAccurate(latitude, longitude)).thenReturn(region);
             when(placeRepository.save(any(Place.class))).thenReturn(place);
             when(articleImageUploadService.uploadImages(place, region, null, null)).thenReturn(photos);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(member, category, place, region, request.title(), request.date(), request.content())).thenReturn(article);
             when(articleRepository.save(article)).thenReturn(article);
             when(articleImageUploadService.saveImagesWithArticle(photos, article)).thenReturn(photos);
 
@@ -407,7 +399,7 @@ class ArticleCommandServiceImplTest {
             when(regionRepository.findRegionByCoordinatesAccurate(latitude, longitude)).thenReturn(region);
             when(placeRepository.save(any(Place.class))).thenReturn(place);
             when(articleImageUploadService.uploadImages(place, region, mainImage, imageFiles)).thenReturn(photos);
-            when(articleFactory.create(member, category, place, region, request)).thenReturn(article);
+            when(articleFactory.create(member, category, place, region, request.title(), request.date(), request.content())).thenReturn(article);
             when(articleRepository.save(article)).thenReturn(article);
             when(articleImageUploadService.saveImagesWithArticle(photos, article)).thenReturn(photos);
 


### PR DESCRIPTION
## #️⃣ 기능 설명
>Article 도메인의 캡슐화 강화 및 서비스 계층의 책임을 명확히 하기 위한 리팩토링 작업입니다.

## 🛠️ 작업 상세 내용
- [x] `ArticleFactory`, `ArticleUpdater `등 도메인 계층에서 외부 의존성(Repository/DTO) 제거
- [x] 서비스 계층에서 엔티티/값을 조회 및 전달하는 구조로 변경
- [x] 관련 테스트 코드 및 서비스 계층 코드 수정

## 📸 스크린샷 (선택)

## 💬 기타(공유사항 to 리뷰어)
- 도메인 계층은 상태 변경 및 생성 책임만 갖도록 하였습니다.
- 서비스 계층에서 외부 의존성(Repository, DTO 등)을 모두 관리하도록 변경하였습니다.
- **계층형 구조의 통일성과 도메인 캡슐화의 균형을 고려하여,**
  - **생성 책임은 Factory에, 수정 책임은 엔티티에 위임**하였습니다.
